### PR TITLE
feature/alt-on-create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] 2025-05-01
+
+### Added
+- Adding new feature to generate AI alt text on the `ELEMENT::EVENT_AFTER_SAVE` event
+- Adding new setting to allow users to generate alt text on upload
+
+### Changed
+- Updating setting descriptions to be more concise
+- Refactored logic within the plugin to re-use code, removing dupe code
+- Improved main logic within service method to generate alt text for current site off-queue so results can be visualised near immediately
+- Refactoring code to be suitable for php8.2
+- Removing unused imported classes
+- Improved logic so current siteId could be passed through and saved before others
+- Updating variables to be more consice, e.g. now $asset instead of $element
 
 ## [1.3.2] - 2025-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,8 +145,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - None (initial release)
-
-## [Unreleased]
-
-### Added
-- Added "Generate for new assets" setting to automatically generate alt text when new assets are created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - None (initial release)
+
+## [Unreleased]
+
+### Added
+- Added "Generate for new assets" setting to automatically generate alt text when new assets are created

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can also generate alt text for a single asset by:
 2. Clicking the action menu `...` icon in the top-right corner
 3. Selecting **Generate AI Alt Text** from the dropdown menu
 
+Alternatively, you can enable the "Generate for new assets" option in the plugin settings to automatically generate alt text for newly uploaded assets.
+
 ![CraftCMS asset library table with two assets selected and the 'Generate AI Alt Text' option visible in the dropdown.](src/generate-ai-alt-text-elements-action-example.png)
 
 Example twig:
@@ -87,6 +89,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Prompt** | The text prompt sent to the AI to generate alt text. Supports `{asset.property}` and `{site.property}` | See below |
 | **Image Detail Level** | How detailed the image analysis should be. | `low` |
 | **Pre-save Asset** | Whether to pre-save the asset if alt field is empty before saving a value to it. This prevents the same initial value being saved to each Site. | `true` |
+| **Generate for new assets** | Whether to automatically generate alt text when new assets are created. | `false` |
 | **Save Translated Results to Each Site** | Whether to save translated results to an Asset's translatable alt text field for each Site. | `false` |
 
 #### 🧠 Model Options

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -124,7 +124,9 @@ class AiAltText extends Plugin
                     && $this->getSettings()->generateForNewAssets
                     && (empty($asset->alt) || $asset->alt === '')
                 ) {
-                    Craft::$app->getQueue()->push(new GenerateAiAltTextJob([
+                    $queue = Craft::$app->getQueue();
+                    
+                    $queue->push(new GenerateAiAltTextJob([
                         'description' => Craft::t('ai-alt-text', 'Generating alt text for new asset {filename} (Element: {id}, Site: {siteId})', [
                             'filename' => $asset->filename,
                             'id' => $asset->id,
@@ -133,11 +135,12 @@ class AiAltText extends Plugin
                         'elementId' => $asset->id,
                         'siteId' => $asset->siteId,
                     ]));
-
+                    
                     $plugin = AiAltText::getInstance();
                     // If we're saving results to each site, queue a job for each site
                     $saveTranslatedResultsToEachSite = $plugin->settings->saveTranslatedResultsToEachSite;
                     if ($saveTranslatedResultsToEachSite) {
+                        $siteId = $asset->siteId;
                         foreach (Craft::$app->getSites()->getAllSites() as $site) {
                             // Skip the current site
                             if ($site->id === $siteId) {
@@ -155,7 +158,6 @@ class AiAltText extends Plugin
                             ]));
                         }
                     }
-
                     
                     Craft::info(
                         "Queued AI alt text generation for new asset: {$asset->filename}",

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -114,15 +114,14 @@ class AiAltText extends Plugin
             Asset::class,
             Element::EVENT_AFTER_SAVE,
             function(ModelEvent $event) {
-                /** @var Asset $asset */
-                $asset = $event->sender;
+                /** @var Asset $element */
+                $element = $event->sender;
                 
                 // Only process new assets that are images and if the setting is enabled
                 if (
                     $event->isNew 
-                    && $asset->kind === Asset::KIND_IMAGE
+                    && $element->kind === Asset::KIND_IMAGE
                     && $this->getSettings()->generateForNewAssets
-                    && (empty($asset->alt) || $asset->alt === '')
                 ) {
                     $elementsService = Craft::$app->getElements();
                     $queue = Craft::$app->getQueue();

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -4,24 +4,14 @@ namespace heavymetalavo\craftaialttext;
 
 use Craft;
 use craft\base\Element;
-use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\Asset;
-use craft\events\ElementEvent;
 use craft\events\ModelEvent;
 use craft\events\RegisterElementActionsEvent;
-use craft\events\RegisterElementDefaultTableAttributesEvent;
-use craft\events\RegisterElementTableAttributesEvent;
 use craft\events\DefineMenuItemsEvent;
-use craft\helpers\Assets;
-use craft\helpers\ElementHelper;
-use craft\helpers\Html;
-use craft\helpers\Template;
 use craft\web\View;
 use craft\web\UrlManager;
-use craft\enums\MenuItemType;
 use heavymetalavo\craftaialttext\elements\actions\GenerateAiAltText;
-use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
 use heavymetalavo\craftaialttext\services\AiAltTextService;
 use heavymetalavo\craftaialttext\models\Settings;
 use yii\base\Event;
@@ -108,7 +98,7 @@ class AiAltText extends Plugin
                 $this->aiAltTextService->handleAssetActionMenuItems($event);
             }
         );
-        
+
         // Listen for asset creation/save events
         Event::on(
             Asset::class,
@@ -116,10 +106,10 @@ class AiAltText extends Plugin
             function(ModelEvent $event) {
                 /** @var Asset $element */
                 $element = $event->sender;
-                
+
                 // Only process new assets that are images and if the setting is enabled
                 if (
-                    $event->isNew 
+                    $event->isNew
                     && $element->kind === Asset::KIND_IMAGE
                     && $this->getSettings()->generateForNewAssets
                 ) {

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -8,6 +8,7 @@ use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\Asset;
 use craft\events\ElementEvent;
+use craft\events\ModelEvent;
 use craft\events\RegisterElementActionsEvent;
 use craft\events\RegisterElementDefaultTableAttributesEvent;
 use craft\events\RegisterElementTableAttributesEvent;
@@ -112,9 +113,9 @@ class AiAltText extends Plugin
         Event::on(
             Asset::class,
             Element::EVENT_AFTER_SAVE,
-            function(ElementEvent $event) {
+            function(ModelEvent $event) {
                 /** @var Asset $asset */
-                $asset = $event->element;
+                $asset = $event->sender;
                 
                 // Only process new assets that are images and if the setting is enabled
                 if (

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -123,46 +123,7 @@ class AiAltText extends Plugin
                     && $element->kind === Asset::KIND_IMAGE
                     && $this->getSettings()->generateForNewAssets
                 ) {
-                    $elementsService = Craft::$app->getElements();
-                    $queue = Craft::$app->getQueue();
-                    // Check if there's already a job for this element
-                    $existingJobs = $queue->getJobInfo();
-                    $hasExistingJob = false;
-                    foreach ($existingJobs as $job) {
-                        if (isset($job['description']) && strpos($job['description'], "Element: {$element->id}") !== false) {
-                            $hasExistingJob = true;
-                            break;
-                        }
-                    }
-
-                    if ($hasExistingJob) {
-                        Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "{$element->filename} (ID: {$element->id}) is already being processed within an existing queued job. Please wait for the existing job to finish before attempting to process it again."));
-                        return;
-                    }
-
-                    if ($element->kind !== Asset::KIND_IMAGE) {
-                        Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "{$element->filename} (ID: {$element->id}) is not an image"));
-                        return;
-                    }
-
-                    $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;
-
-                    // If we're saving results to each site and translated results for each site, we need to queue a job for each site
-                    if ($saveTranslatedResultsToEachSite) {
-                        foreach (Craft::$app->getSites()->getAllSites() as $site) {
-
-                            $queue->push(new GenerateAiAltTextJob([
-                                'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Element: {id}, Site: {siteId})', [
-                                    'filename' => $element->filename,
-                                    'id' => $element->id,
-                                    'siteId' => $site->id,
-                                ]),
-                                'elementId' => $element->id,
-                                'siteId' => $site->id,
-                            ]));
-                        }
-                    }
-                    
+                    AiAltText::getInstance()->aiAltTextService->createJob($element);
                 }
             }
         );

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -45,7 +45,7 @@ class GenerateController extends Controller
         $this->requirePermission('saveAssets:' . $asset->getVolume()->uid);
 
         try {
-            AiAltText::getInstance()->aiAltTextService->createJob($element);
+            AiAltText::getInstance()->aiAltTextService->createJob($asset, true);
 
             // Return success
             return $this->asJson([

--- a/src/elements/actions/GenerateAiAltText.php
+++ b/src/elements/actions/GenerateAiAltText.php
@@ -59,7 +59,7 @@ class GenerateAiAltText extends ElementAction
             throw new InvalidConfigException('User not logged in');
         }
 
-        foreach ($query->all() as $sset) {
+        foreach ($query->all() as $asset) {
             if (!$asset instanceof Asset) {
                 continue;
             }

--- a/src/elements/actions/GenerateAiAltText.php
+++ b/src/elements/actions/GenerateAiAltText.php
@@ -6,10 +6,7 @@ use Craft;
 use craft\base\ElementAction;
 use craft\elements\Asset;
 use craft\elements\db\ElementQueryInterface;
-use craft\helpers\ElementHelper;
-use craft\helpers\Queue;
 use heavymetalavo\craftaialttext\AiAltText;
-use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
 use yii\base\InvalidConfigException;
 
 /**
@@ -62,17 +59,12 @@ class GenerateAiAltText extends ElementAction
             throw new InvalidConfigException('User not logged in');
         }
 
-        $elementsService = Craft::$app->getElements();
-        $queue = Craft::$app->getQueue();
-
         foreach ($query->all() as $element) {
             if (!$element instanceof Asset) {
                 continue;
             }
 
             AiAltText::getInstance()->aiAltTextService->createJob($element, true);
-            
-
         }
 
         return true;

--- a/src/elements/actions/GenerateAiAltText.php
+++ b/src/elements/actions/GenerateAiAltText.php
@@ -59,12 +59,16 @@ class GenerateAiAltText extends ElementAction
             throw new InvalidConfigException('User not logged in');
         }
 
-        foreach ($query->all() as $element) {
-            if (!$element instanceof Asset) {
+        foreach ($query->all() as $sset) {
+            if (!$asset instanceof Asset) {
                 continue;
             }
 
-            AiAltText::getInstance()->aiAltTextService->createJob($element, true);
+            // Set the current site id on asset
+            $asset = Asset::find()->id($asset->id)->siteId($query->siteId)->one();
+
+            // Create a job for the asset
+            AiAltText::getInstance()->aiAltTextService->createJob($asset, true);
         }
 
         return true;

--- a/src/jobs/GenerateAiAltText.php
+++ b/src/jobs/GenerateAiAltText.php
@@ -15,7 +15,7 @@ use yii\base\Exception;
  */
 class GenerateAiAltText extends BaseJob
 {
-    public ?int $elementId = null;
+    public ?int $assetId = null;
     public ?int $siteId = null;
 
     /**
@@ -27,11 +27,11 @@ class GenerateAiAltText extends BaseJob
     {
         try {
             // query for the asset
-            $asset = Asset::find()->id($this->elementId)->siteId($this->siteId)->one();
+            $asset = Asset::find()->id($this->assetId)->siteId($this->siteId)->one();
 
             // check if the asset exists
             if (!$asset) {
-                throw new ElementNotFoundException("Asset not found: {$this->elementId}");
+                throw new ElementNotFoundException("Asset not found: {$this->assetId}");
             }
 
             // Generate alt text - now returns a string and saves the asset if successful
@@ -39,9 +39,9 @@ class GenerateAiAltText extends BaseJob
 
             // Log the result
             if (!empty($altText)) {
-                Craft::info("Successfully generated alt text for asset {$this->elementId}: " . $altText, __METHOD__);
+                Craft::info("Successfully generated alt text for asset {$this->assetId}: " . $altText, __METHOD__);
             } else {
-                Craft::warning("Failed to generate alt text for asset {$this->elementId}", __METHOD__);
+                Craft::warning("Failed to generate alt text for asset {$this->assetId}", __METHOD__);
                 // Set the description to indicate failure
                 $this->description = "Failed to generate alt text";
             }

--- a/src/jobs/GenerateAiAltText.php
+++ b/src/jobs/GenerateAiAltText.php
@@ -23,7 +23,7 @@ class GenerateAiAltText extends BaseJob
      * @throws Exception
      * @throws Throwable
      */
-    function execute(): void
+    function execute($queue): void
     {
         try {
             // query for the asset

--- a/src/jobs/GenerateAiAltText.php
+++ b/src/jobs/GenerateAiAltText.php
@@ -23,7 +23,7 @@ class GenerateAiAltText extends BaseJob
      * @throws Exception
      * @throws Throwable
      */
-    function execute($queue): void
+    function execute(): void
     {
         try {
             // query for the asset
@@ -31,7 +31,7 @@ class GenerateAiAltText extends BaseJob
 
             // check if the asset exists
             if (!$asset) {
-                throw new ElementNotFoundException("Asset not found: {$this->assetId}");
+                throw new ElementNotFoundException("Asset not found: $this->assetId");
             }
 
             // Generate alt text - now returns a string and saves the asset if successful
@@ -39,9 +39,9 @@ class GenerateAiAltText extends BaseJob
 
             // Log the result
             if (!empty($altText)) {
-                Craft::info("Successfully generated alt text for asset {$this->assetId}: " . $altText, __METHOD__);
+                Craft::info("Successfully generated alt text for asset $this->assetId: " . $altText, __METHOD__);
             } else {
-                Craft::warning("Failed to generate alt text for asset {$this->assetId}", __METHOD__);
+                Craft::warning("Failed to generate alt text for asset $this->assetId", __METHOD__);
                 // Set the description to indicate failure
                 $this->description = "Failed to generate alt text";
             }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -18,6 +18,7 @@ use craft\base\Model;
  * @property bool $preSaveAsset Whether to pre-save the asset if alt field is empty before saving a value to it, prevents same value being saved to each Site
  * @property bool $saveTranslatedResultsToEachSite Whether to save the translated result to each Site's Asset's translatable alt text field
  * @property string $translationPromptAppendage The prompt suffix for translated results
+ * @property bool $generateForNewAssets Whether to generate alt text for new assets automatically
  */
 class Settings extends Model
 {
@@ -57,6 +58,11 @@ class Settings extends Model
     public bool $saveTranslatedResultsToEachSite = false;
 
     /**
+     * @var bool Whether to generate alt text for new assets automatically
+     */
+    public bool $generateForNewAssets = false;
+
+    /**
      * @inheritdoc
      */
     public function defineRules(): array
@@ -70,6 +76,7 @@ class Settings extends Model
             ['openAiImageInputDetailLevel', 'in', 'range' => ['low', 'high']],
             ['preSaveAsset', 'boolean'],
             ['saveTranslatedResultsToEachSite', 'boolean'],
+            ['generateForNewAssets', 'boolean'],
         ];
     }
 }

--- a/src/models/api/OpenAiRequest.php
+++ b/src/models/api/OpenAiRequest.php
@@ -6,10 +6,10 @@ use craft\base\Model;
 
 /**
  * OpenAI Request Model
- * 
+ *
  * Represents a request to the OpenAI API for vision analysis.
  * This model handles the structure and validation of API requests, including the model to use and input to send.
- * 
+ *
  * @property string $model The OpenAI model to use (e.g., 'gpt-4o-mini')
  * @property array $input The input array containing the role and content
  * @property-read string $detail The detail level for image analysis
@@ -18,24 +18,24 @@ class OpenAiRequest extends Model
 {
     public string $model = '';
     public array $input = [];
-    
+
     private string $prompt = '';
     private string $imageUrl = '';
     private string $detail = 'low';
 
     /**
      * Gets the detail level for image analysis
-     * 
+     *
      * @return string The detail level
      */
     public function getDetail(): string
     {
         return $this->detail;
     }
-    
+
     /**
      * Sets the prompt text for the request
-     * 
+     *
      * @param string $prompt The prompt text to use
      * @return self For method chaining
      */
@@ -45,10 +45,10 @@ class OpenAiRequest extends Model
         $this->buildInput();
         return $this;
     }
-    
+
     /**
      * Sets the image URL for the request
-     * 
+     *
      * @param string $imageUrl The URL of the image to analyze
      * @return self For method chaining
      */
@@ -58,10 +58,10 @@ class OpenAiRequest extends Model
         $this->buildInput();
         return $this;
     }
-    
+
     /**
      * Sets the detail level for image analysis
-     * 
+     *
      * @param string $detail The detail level (auto, low, or high)
      * @return self For method chaining
      */
@@ -71,14 +71,14 @@ class OpenAiRequest extends Model
         $this->buildInput();
         return $this;
     }
-    
+
     /**
      * Builds the input array structure from the current properties
      */
     private function buildInput(): void
     {
         $content = [];
-        
+
         // Add text content if prompt is set
         if (!empty($this->prompt)) {
             $content[] = [
@@ -86,7 +86,7 @@ class OpenAiRequest extends Model
                 'text' => $this->prompt
             ];
         }
-        
+
         // Add image content if imageUrl is set
         if (!empty($this->imageUrl)) {
             $content[] = [
@@ -95,7 +95,7 @@ class OpenAiRequest extends Model
                 'detail' => $this->detail
             ];
         }
-        
+
         // Set the input array with the built content
         $this->input = [
             [
@@ -107,7 +107,7 @@ class OpenAiRequest extends Model
 
     /**
      * Defines the validation rules for the request model.
-     * 
+     *
      * @return array The validation rules
      */
     public function defineRules(): array
@@ -116,18 +116,16 @@ class OpenAiRequest extends Model
             [['model', 'input'], 'required'],
             ['model', 'string'],
             ['input', 'safe'],
-            ['model', 'validateDetail'], 
+            ['model', 'validateDetail'],
         ];
     }
-    
+
     /**
      * Validates the detail property
      *
-     * @param string $attribute The attribute being validated (not used, but required by validator)
-     * @param mixed $params Validator parameters (not used, but required by validator)
      * @return void
      */
-    public function validateDetail($attribute, $params): void
+    public function validateDetail(): void
     {
         // Custom validator for detail value
         if (!in_array($this->detail, ['auto', 'low', 'high'])) {
@@ -147,7 +145,7 @@ class OpenAiRequest extends Model
         };
         return $fields;
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -159,4 +157,4 @@ class OpenAiRequest extends Model
             'input' => $this->input,
         ];
     }
-} 
+}

--- a/src/models/api/OpenAiResponse.php
+++ b/src/models/api/OpenAiResponse.php
@@ -9,10 +9,10 @@ use Craft;
 
 /**
  * OpenAI Response Model
- * 
+ *
  * Represents a response from the OpenAI API.
  * This model handles the structure and validation of API responses, including the generated content and any errors.
- * 
+ *
  * @property string $output_text The generated content from the API
  * @property array|null $output The full output structure from the API
  * @property array|null $content The content array from the API
@@ -29,7 +29,7 @@ class OpenAiResponse extends Model
 
     /**
      * Parse the API response and populate the model properties
-     * 
+     *
      * @param string $responseBody The raw response body from the API
      * @return bool True if parsing was successful, false otherwise
      */
@@ -50,19 +50,19 @@ class OpenAiResponse extends Model
                 $errorMessage = is_array($responseData['error'])
                     ? ($responseData['error']['message'] ?? Json::encode($responseData['error']))
                     : $responseData['error'];
-                $this->setError($errorMessage, $responseData['error'] ?? null);
+                $this->setError($errorMessage, $responseData['error']);
                 return false;
             }
 
             // Store the output if it exists
             if (isset($responseData['output']) && is_array($responseData['output'])) {
                 $this->output = $responseData['output'];
-                
+
                 // Look for the message in the output array
                 foreach ($responseData['output'] as $outputItem) {
                     if (isset($outputItem['content']) && is_array($outputItem['content'])) {
                         $this->content = $outputItem['content'];
-                        
+
                         // Look for the text content
                         foreach ($outputItem['content'] as $contentItem) {
                             if (isset($contentItem['type']) && $contentItem['type'] === 'output_text' && isset($contentItem['text'])) {
@@ -103,7 +103,7 @@ class OpenAiResponse extends Model
 
     /**
      * Set an error message on the response
-     * 
+     *
      * @param string $message The error message
      * @param array|null $details Additional error details
      */
@@ -117,7 +117,7 @@ class OpenAiResponse extends Model
 
     /**
      * Get the raw response data
-     * 
+     *
      * @return array|null The raw response data
      */
     public function getRawData(): ?array
@@ -127,7 +127,7 @@ class OpenAiResponse extends Model
 
     /**
      * Defines the validation rules for the response model.
-     * 
+     *
      * @return array The validation rules
      */
     public function defineRules(): array
@@ -142,7 +142,7 @@ class OpenAiResponse extends Model
 
     /**
      * Checks if the response contains an error.
-     * 
+     *
      * @return bool True if there is an error, false otherwise
      */
     public function hasError(): bool
@@ -152,7 +152,7 @@ class OpenAiResponse extends Model
 
     /**
      * Gets the error message from the response.
-     * 
+     *
      * @return string The error message, or an empty string if there is no error
      */
     public function getErrorMessage(): string
@@ -162,7 +162,7 @@ class OpenAiResponse extends Model
 
     /**
      * Gets the generated text from the response.
-     * 
+     *
      * @return string The generated text
      */
     public function getText(): string
@@ -183,4 +183,4 @@ class OpenAiResponse extends Model
 
         return $data;
     }
-} 
+}

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -87,6 +87,22 @@ class AiAltTextService extends Component
             }
         }
 
+        // Save the current site on queue
+        $queue->push(new GenerateAiAltTextJob([
+            'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
+                'filename' => $asset->filename,
+                'id' => $asset->id,
+                'siteId' => $site->id,
+            ]),
+            'assetId' => $asset->id,
+            'siteId' => $site->id,
+        ]));
+
+        // return early if we're not saving translated results to each site
+        if (!$saveTranslatedResultsToEachSite) {
+            return;
+        }
+
         // If we're saving results to each site and translated results for each site, we need to queue a job for each site
         foreach (Craft::$app->getSites()->getAllSites() as $site) {
             // Skip the current site

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -5,13 +5,8 @@ namespace heavymetalavo\craftaialttext\services;
 use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
-use craft\helpers\Assets;
-use craft\helpers\ElementHelper;
-use craft\helpers\Html;
-use craft\helpers\Template;
-use craft\web\View;
 use heavymetalavo\craftaialttext\AiAltText;
-use craft\helpers\App;
+use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
 use Exception;
 use craft\events\DefineMenuItemsEvent;
 use craft\enums\MenuItemType;
@@ -116,8 +111,7 @@ class AiAltTextService extends Component
         }
 
         $asset->alt = $altText;
-        $runValidation = true;
-        if (!Craft::$app->elements->saveElement($asset, $runValidation)) {
+        if (!Craft::$app->elements->saveElement($asset, true)) {
             throw new Exception('Failed to save alt text for asset: ' . $asset->filename);
         }
 

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -60,13 +60,17 @@ class AiAltTextService extends Component
             return;
         }
 
+        // Get the $saveTranslatedResultsToEachSite setting value
         $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;
+
+        // Get the current site id
+        $currentSiteId = Craft::$app->sites->getCurrentSite()->id ?? $asset->siteId;
 
         // Check if we need to save the current site off queue
         if ($saveCurrentSiteOffQueue) {
             try {
                 // Generate alt text - now returns a string and saves the asset if successful
-                $altText = AiAltText::getInstance()->aiAltTextService->generateAltText($asset, $this->siteId);
+                $altText = AiAltText::getInstance()->aiAltTextService->generateAltText($asset, $currentSiteId);
     
                 // Log the result
                 if (!empty($altText)) {
@@ -92,10 +96,10 @@ class AiAltTextService extends Component
             'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
-                'siteId' => $asset->siteId,
+                'siteId' => $currentSiteId,
             ]),
             'assetId' => $asset->id,
-            'siteId' => $asset->siteId,
+            'siteId' => $currentSiteId,
         ]));
 
         // return early if we're not saving translated results to each site
@@ -106,7 +110,7 @@ class AiAltTextService extends Component
         // If we're saving results to each site and translated results for each site, we need to queue a job for each site
         foreach (Craft::$app->getSites()->getAllSites() as $site) {
             // Skip the current site
-            if ($saveCurrentSiteOffQueue && $site->id === $asset->siteId) {
+            if ($saveCurrentSiteOffQueue && $site->id === $currentSiteId) {
                 continue;
             }
 

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -61,16 +61,13 @@ class AiAltTextService extends Component
         }
 
         // Get the $saveTranslatedResultsToEachSite setting value
-        $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;
-
-        // Get the current site id
-        $currentSiteId = Craft::$app->sites->getCurrentSite()->id ?? $asset->siteId;
+        $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;;
 
         // Check if we need to save the current site off queue
         if ($saveCurrentSiteOffQueue) {
             try {
                 // Generate alt text - now returns a string and saves the asset if successful
-                $altText = AiAltText::getInstance()->aiAltTextService->generateAltText($asset, $currentSiteId);
+                $altText = AiAltText::getInstance()->aiAltTextService->generateAltText($asset, $asset->siteId);
     
                 // Log the result
                 if (!empty($altText)) {
@@ -96,10 +93,10 @@ class AiAltTextService extends Component
             'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
-                'siteId' => $currentSiteId,
+                'siteId' => $asset->siteId,
             ]),
             'assetId' => $asset->id,
-            'siteId' => $currentSiteId,
+            'siteId' => $asset->siteId,
         ]));
 
         // return early if we're not saving translated results to each site
@@ -110,7 +107,7 @@ class AiAltTextService extends Component
         // If we're saving results to each site and translated results for each site, we need to queue a job for each site
         foreach (Craft::$app->getSites()->getAllSites() as $site) {
             // Skip the current site
-            if ($saveCurrentSiteOffQueue && $site->id === $currentSiteId) {
+            if ($saveCurrentSiteOffQueue && $site->id === $asset->siteId) {
                 continue;
             }
 

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -40,6 +40,52 @@ class AiAltTextService extends Component
     }
 
     /**
+     * Creates a job for the given element
+     */
+    public function createJob(Asset $asset)
+    {
+        $assetsService = Craft::$app->getElements();
+        $queue = Craft::$app->getQueue();
+        // Check if there's already a job for this element
+        $existingJobs = $queue->getJobInfo();
+        $hasExistingJob = false;
+        foreach ($existingJobs as $job) {
+            if (isset($job['description']) && strpos($job['description'], "Asset: {$asset->id}") !== false) {
+                $hasExistingJob = true;
+                break;
+            }
+        }
+
+        if ($hasExistingJob) {
+            Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "{$asset->filename} (ID: {$asset->id}) is already being processed within an existing queued job. Please wait for the existing job to finish before attempting to process it again."));
+            return;
+        }
+
+        if ($asset->kind !== Asset::KIND_IMAGE) {
+            Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "{$asset->filename} (ID: {$asset->id}) is not an image"));
+            return;
+        }
+
+        $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;
+
+        // If we're saving results to each site and translated results for each site, we need to queue a job for each site
+        if ($saveTranslatedResultsToEachSite) {
+            foreach (Craft::$app->getSites()->getAllSites() as $site) {
+
+                $queue->push(new GenerateAiAltTextJob([
+                    'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
+                        'filename' => $asset->filename,
+                        'id' => $asset->id,
+                        'siteId' => $site->id,
+                    ]),
+                    'assetId' => $asset->id,
+                    'siteId' => $site->id,
+                ]));
+            }
+        }   
+    }
+
+    /**
      * Generates alt text for an asset using AI.
      *
      * This method:

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -65,24 +65,8 @@ class AiAltTextService extends Component
 
         // Check if we need to save the current site off queue
         if ($saveCurrentSiteOffQueue) {
-            try {
-                // Generate alt text - now returns a string and saves the asset if successful
-                $altText = AiAltText::getInstance()->aiAltTextService->generateAltText($asset, $asset->siteId);
+            $this->generateAltText($asset, $asset->siteId);
     
-                // Log the result
-                if (!empty($altText)) {
-                    Craft::info("Successfully generated alt text for asset $this->assetId: " . $altText, __METHOD__);
-                } else {
-                    Craft::warning("Failed to generate alt text for asset $this->assetId", __METHOD__);
-                    // Set the description to indicate failure
-                    $this->description = "Failed to generate alt text";
-                }
-            } catch (Exception $e) {
-                Craft::error("Error in GenerateAiAltText job: " . $e->getMessage(), __METHOD__);
-                // Set the description to indicate error
-                $this->description = "Error: " . $e->getMessage();
-            }
-            
             if (!$saveTranslatedResultsToEachSite) {
                 return;
             }

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -92,10 +92,10 @@ class AiAltTextService extends Component
             'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
-                'siteId' => $site->id,
+                'siteId' => $asset->siteId,
             ]),
             'assetId' => $asset->id,
-            'siteId' => $site->id,
+            'siteId' => $asset->siteId,
         ]));
 
         // return early if we're not saving translated results to each site

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -79,7 +79,7 @@
     label: 'Save translated results for each Site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',
-    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, alt text will generate for the Current Site, or the Default Site when uploading a new asset."|t("aialttext"),
+    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, alt text will generate for the Current Site for existing assets, or the Default Site when uploading a new asset."|t("aialttext"),
     on: settings.saveTranslatedResultsToEachSite,
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -66,14 +66,7 @@
     errors: settings.getErrors('preSaveAsset'),
 }) }}
 
-{{ forms.lightswitchField({
-    label: 'Generate for new assets'|t('aialttext'),
-    id: 'generateForNewAssets',
-    name: 'generateForNewAssets',
-    instructions: "If enabled, the plugin will automatically generate alt text when an image assets is created (on upload)"|t("aialttext"),
-    on: settings.generateForNewAssets,
-    errors: settings.getErrors('generateForNewAssets'),
-}) }}
+
 
 {{ forms.lightswitchField({
     label: 'Save translated results for each Site'|t('aialttext'),

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -79,7 +79,7 @@
     label: 'Save translated results for each Site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',
-    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, the related Site content within the prompt will work for the \"Current Site\" only."|t("aialttext"),
+    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, the related Site content within the prompt will work for the \"Default Site\" only."|t("aialttext"),
     on: settings.saveTranslatedResultsToEachSite,
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -67,6 +67,15 @@
 }) }}
 
 {{ forms.lightswitchField({
+    label: 'Generate for new assets'|t('aialttext'),
+    id: 'generateForNewAssets',
+    name: 'generateForNewAssets',
+    instructions: "If enabled, the plugin will automatically generate alt text when new assets are created"|t("aialttext"),
+    on: settings.generateForNewAssets,
+    errors: settings.getErrors('generateForNewAssets'),
+}) }}
+
+{{ forms.lightswitchField({
     label: 'Save translated results for each Site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -66,7 +66,14 @@
     errors: settings.getErrors('preSaveAsset'),
 }) }}
 
-
+{{ forms.lightswitchField({
+    label: 'Generate for new image assets (on upload)'|t('aialttext'),
+    id: 'generateForNewAssets',
+    name: 'generateForNewAssets',
+    instructions: "If enabled, the plugin will automatically generate alt text when an image assets is created (on upload)"|t("aialttext"),
+    on: settings.generateForNewAssets,
+    errors: settings.getErrors('generateForNewAssets'),
+}) }}
 
 {{ forms.lightswitchField({
     label: 'Save translated results for each Site'|t('aialttext'),

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -70,7 +70,7 @@
     label: 'Generate for new assets'|t('aialttext'),
     id: 'generateForNewAssets',
     name: 'generateForNewAssets',
-    instructions: "If enabled, the plugin will automatically generate alt text when new assets are created"|t("aialttext"),
+    instructions: "If enabled, the plugin will automatically generate alt text when an image assets is created (on upload)"|t("aialttext"),
     on: settings.generateForNewAssets,
     errors: settings.getErrors('generateForNewAssets'),
 }) }}
@@ -79,7 +79,7 @@
     label: 'Save translated results for each Site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',
-    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, the related Site content within the prompt will work for the \"Default Site\" only."|t("aialttext"),
+    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, alt text will generate for the Current Site, or the Default Site when uploading a new asset."|t("aialttext"),
     on: settings.saveTranslatedResultsToEachSite,
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}


### PR DESCRIPTION
## Changes

- Adding new feature to generate AI alt text on the `ELEMENT::EVENT_AFTER_SAVE` event
- Updating setting descriptions to be more concise
- Adding new setting to allow users to generate alt text on upload
- Refactored logic within the plugin to re-use code, removing dupe code
- Improved main logic within service method to generate alt text for current site off-queue so results can be visualised near immediately
- Refactoring code to be suitable for php8.2
- Removing unused imported classes
- Improved logic so current siteId could be passed through and saved before others
- Updating variables to be more consice, e.g. now $asset instead of $element