### PR TITLE
dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for AI Alt Text
 
-## 1.5.5-unreleased
+## 1.5.5 - 2025-05-16
 
 - ✅ Adding limitations to readme
 - ✅ Adding test to ensure file size is under 20MB API limit
@@ -9,9 +9,7 @@
 - ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
 - ✅ Update logic to support new API limitation "768px (short side) x 2000px (long side)"
 - ✅ Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
-- Update bulk actions table to only show 1 "total" row where there is only 1 site
-- Fixed issue where remote SVGs were not sending a jpg transform to OpenAI
-- Added option to select alt text field from field list
+- ✅ Update bulk actions table to only show 1 "total" row where there is only 1 site
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - ✅ Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
 - ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
 - Update logic to support new API limitation "768px (short side) x 2000px (long side)"
+- Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
+- Fixed issue where remote SVGs were not sending a jpg transform to openai
+- Added option to select alt text field from field list
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 - ✅ Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
 - ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
 - ✅ Update logic to support new API limitation "768px (short side) x 2000px (long side)"
-- Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
-- Fixed issue where remote SVGs were not sending a jpg transform to openai
+- ✅ Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
+- Update bulk actions table to only show 1 "total" row where there is only 1 site
+- Fixed issue where remote SVGs were not sending a jpg transform to OpenAI
 - Added option to select alt text field from field list
 
 ## 1.5.4 - 2025-05-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## 1.5.5 - 2025-05-16
 
-- ✅ Adding limitations to readme
-- ✅ Adding test to ensure file size is under 20MB API limit
-- ✅ Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
-- ✅ Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
-- ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
-- ✅ Update logic to support new API limitation "768px (short side) x 2000px (long side)"
-- ✅ Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
-- ✅ Update bulk actions table to only show 1 "total" row where there is only 1 site
+- Adding limitations to readme
+- Adding test to check file size is under 20MB API limit, in super unlikely scenario where it is larger and within the required dimensions perform a transform where quality is reduced further
+- Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
+- Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
+- Update logic to support new API dimensions limitation "768px (short side) x 2000px (long side)"
+- Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
+- Update bulk actions table to only show 1 "total" row where there is only 1 site
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update logic to support new API dimensions limitation "768px (short side) x 2000px (long side)"
 - Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
 - Update bulk actions table to only show 1 "total" row where there is only 1 site
+- Update some thrown exceptions to instead become Craft wanings, turns out the API may accept other files anyway!
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## 1.5.5 - 2025-05-16
 
-- Adding limitations to readme
-- Adding test to check file size is under 20MB API limit, in super unlikely scenario where it is larger and within the required dimensions perform a transform where quality is reduced further
+- Update some thrown exceptions to instead become Craft wanings, turns out the API may accept other files anyway!
 - Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
+- Adding test to check file size is under 20MB API limit, in super unlikely scenario where it is larger and within the required dimensions perform a transform where quality is reduced further
 - Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
+- Adding limitations to readme
 - Update logic to support new API dimensions limitation "768px (short side) x 2000px (long side)"
 - Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
 - Update bulk actions table to only show 1 "total" row where there is only 1 site
-- Update some thrown exceptions to instead become Craft wanings, turns out the API may accept other files anyway!
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes for AI Alt Text
 
+## 1.5.5-unreleased
+
+- Adding limitations to readme
+- Adding test to ensure file size is under 20MB API limit
+- Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
+- Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
+- Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
+
 ## 1.5.4 - 2025-05-09
 
 - Removing unused variable `$extension` missed from removing the extension tests in v1.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 1.5.5-unreleased
 
-- Adding limitations to readme
-- Adding test to ensure file size is under 20MB API limit
-- Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
-- Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
-- Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
+- ✅ Adding limitations to readme
+- ✅ Adding test to ensure file size is under 20MB API limit
+- ✅ Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
+- ✅ Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
+- ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
+- Update logic to support new API limitation "768px (short side) x 2000px (long side)"
 
 ## 1.5.4 - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - ✅ Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
 - ✅ Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
 - ✅ Replacing references to `$assetTransform` with `$asset` as we are updating the model with `setTransform()`, they should be the same.
-- Update logic to support new API limitation "768px (short side) x 2000px (long side)"
+- ✅ Update logic to support new API limitation "768px (short side) x 2000px (long side)"
 - Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
 - Fixed issue where remote SVGs were not sending a jpg transform to openai
 - Added option to select alt text field from field list

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -122,6 +122,35 @@ To add this field:
 5. Save changes to the volume
 6. Update your templates to use the new `alt` field
 
+## Limitations
+
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which have changed in the past month (2025-05), however these requirements don't appear to be enforced, e.g. sending a base64 image above required image dimensions will be accepted by the API.
+- Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
+- The plugin checks a file's mimetype to see if it's valid, [a filename which contains the wrong extension could return the wrong file type until Craft v5.8.0 is released](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
+- If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
+- If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
+- Where an alternative image transformer is used, e.g. when an application is hosted on [Servd](https://servd.host) and assets are processed through their asset platform this may not support svg -> raster transforms
+
+### Supported file types	
+
+- PNG (.png)
+- JPEG (.jpeg and .jpg)
+- WEBP (.webp)
+- Non-animated GIF (.gif)
+
+### Size limits	
+
+- Up to 20MB per image
+- Low-resolution: 512px x 512px
+- High-resolution: 768px (short side) x 2000px (long side)
+
+### Other requirements	
+
+- No watermarks or logos
+- No text
+- No NSFW content
+- Clear enough for a human to understand
+
 ## 🛠️ Troubleshooting
 
 - If the plugin returns errors about API authentication, verify your API key.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,34 @@ To add this field:
 5. Save changes to the volume
 6. Update your templates to use the new `alt` field
 
+## Limitations
+
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which can change
+- Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
+- The plugin checks a file's mimetype to see if it's valid, [a filename contains the wrong extension this should not matter in craft ^5.8](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
+- If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
+- If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
+
+### Supported file types	
+
+- PNG (.png)
+- JPEG (.jpeg and .jpg)
+- WEBP (.webp)
+- Non-animated GIF (.gif)
+
+### Size limits	
+
+- Up to 20MB per image
+- Low-resolution: 512px x 512px
+- High-resolution: 768px (short side) x 2000px (long side)
+
+### Other requirements	
+
+- No watermarks or logos
+- No text
+- No NSFW content
+- Clear enough for a human to understand
+
 ## 🛠️ Troubleshooting
 
 - If the plugin returns errors about API authentication, verify your API key.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ To add this field:
 - The plugin checks a file's mimetype to see if it's valid, [a filename contains the wrong extension this should not matter in craft ^5.8](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
 - If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
 - If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
+- Where an alternative image transformer is used, e.g. when an application is hosted on [Servd](https://servd.host) and assets are processed through their asset platform this may not support svg -> raster transforms
 
 ### Supported file types	
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ To add this field:
 - For "bad request" errors, ensure your selected model supports vision capabilities.
 - Alt text generation is processed through Craft's queue system for bulk operations, so check the queue if generation seems to be taking a long time.
 - Any errors _should_ be logged, check your queue.log files!
+- Check the asset has a title! If somehow an asset exists without one craft will not be able to resave it.
 
 ## ⚠️ Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To add this field:
 
 ## Limitations
 
-- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which have changed in the past month (2025-05)
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which have changed in the past month (2025-05), however these requirements don't appear to be enforced, e.g. sending a base64 image above required image dimensions will be accepted by the API.
 - Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
 - The plugin checks a file's mimetype to see if it's valid, [a filename which contains the wrong extension could return the wrong file type until Craft v5.8.0 is released](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
 - If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ To add this field:
 
 ## Limitations
 
-- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which can change
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which have changed in the past month (2025-05)
 - Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
-- The plugin checks a file's mimetype to see if it's valid, [a filename contains the wrong extension this should not matter in craft ^5.8](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
+- The plugin checks a file's mimetype to see if it's valid, [a filename which contains the wrong extension could return the wrong file type until Craft v5.8.0 is released](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
 - If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
 - If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
 - Where an alternative image transformer is used, e.g. when an application is hosted on [Servd](https://servd.host) and assets are processed through their asset platform this may not support svg -> raster transforms

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -251,7 +251,7 @@ class GenerateController extends Controller
             // Now process each site's assets
             foreach ($sites as $site) {
                 // Process each site
-                Craft::info('Processing ALL assets for site: ' . $site->name . ' (ID: ' . $site->id . ')', __METHOD__);
+                Craft::info('Processing all assets for site: ' . $site->name . ' (ID: ' . $site->id . ')', __METHOD__);
                 
                 // Find all image assets for this site
                 // Process in batches to avoid memory issues

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -94,7 +94,7 @@ class AiAltTextService extends Component
 
         // Save the current site on queue
         $queue->push(new GenerateAiAltTextJob([
-            'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (ID: {id}, Site: {siteId})', [
+            'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (ID: {id}{siteMessageSuffix})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
                 'siteMessageSuffix' => $hasPlusOneSite ? ", Site: $assetSiteId" : "",

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -56,7 +56,7 @@ class AiAltTextService extends Component
             foreach ($existingJobs as $job) {
                 // Only skip if both asset ID AND site ID match an existing job
                 if (isset($job['description'])
-                    && str_contains($job['description'], "Asset: $asset->id")
+                    && str_contains($job['description'], "ID: $asset->id")
                     && str_contains($job['description'], "Site: $assetSiteId")
                     && $job['status'] !== 4) {
                     $hasExistingJob = true;
@@ -94,7 +94,7 @@ class AiAltTextService extends Component
 
         // Save the current site on queue
         $queue->push(new GenerateAiAltTextJob([
-            'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
+            'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (ID: {id}, Site: {siteId})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
                 'siteMessageSuffix' => $hasPlusOneSite ? ", Site: $assetSiteId" : "",
@@ -117,7 +117,7 @@ class AiAltTextService extends Component
             }
 
             $queue->push(new GenerateAiAltTextJob([
-                'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}{siteMessageSuffix})', [
+                'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (ID: {id}{siteMessageSuffix})', [
                     'filename' => $asset->filename,
                     'id' => $asset->id,
                     'siteMessageSuffix' => $hasPlusOneSite ? ", Site: $site->id" : "",

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -64,8 +64,10 @@ class AiAltTextService extends Component
                 }
             }
 
+            $hasPlusOneSite = count(Craft::$app->getSites()->getAllSites()) > 1;
+
             if ($hasExistingJob) {
-                Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "$asset->filename (ID: $asset->id, Site: $assetSiteId) is already being processed within an existing queued job. Please wait for the existing job to finish before attempting to process it again."));
+                Craft::$app->getSession()->setNotice(Craft::t('ai-alt-text', "$asset->filename (ID: $asset->id" . ($hasPlusOneSite ? ", Site: $assetSiteId" : "") . ") is already being processed within an existing queued job. Please wait for the existing job to finish before attempting to process it again."));
                 return;
             }
         }
@@ -87,12 +89,15 @@ class AiAltTextService extends Component
             }
         }
 
+        $sites = Craft::$app->getSites()->getAllSites();
+        $hasPlusOneSite = count($sites) > 1;
+
         // Save the current site on queue
         $queue->push(new GenerateAiAltTextJob([
             'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
                 'filename' => $asset->filename,
                 'id' => $asset->id,
-                'siteId' => $assetSiteId,
+                'siteMessageSuffix' => $hasPlusOneSite ? ", Site: $assetSiteId" : "",
             ]),
             'assetId' => $asset->id,
             'siteId' => $assetSiteId,
@@ -105,17 +110,17 @@ class AiAltTextService extends Component
         }
 
         // If we're saving results to each site and translated results for each site, we need to queue a job for each site
-        foreach (Craft::$app->getSites()->getAllSites() as $site) {
+        foreach ($sites as $site) {
             // Skip the current site
             if ($saveCurrentSiteOffQueue && $site->id === $assetSiteId) {
                 continue;
             }
 
             $queue->push(new GenerateAiAltTextJob([
-                'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}, Site: {siteId})', [
+                'description' => Craft::t('ai-alt-text', 'Generating alt text for {filename} (Asset: {id}{siteMessageSuffix})', [
                     'filename' => $asset->filename,
                     'id' => $asset->id,
-                    'siteId' => $site->id,
+                    'siteMessageSuffix' => $hasPlusOneSite ? ", Site: $site->id" : "",
                 ]),
                 'assetId' => $asset->id,
                 'siteId' => $site->id,

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -249,43 +249,54 @@ class OpenAiService extends Component
             $transformParams['format'] = 'jpg';
         }
 
-        // Determine short side and long side
-        $shortSide = min($width, $height);
-        $longSide = max($width, $height);
-        
-        // Add dimension constraints if needed - OpenAI requires max 768px for short side, 2000px for long side
-        if ($shortSide > 768 || $longSide > 2000) {
-            // Calculate the aspect ratio
-            $aspectRatio = $width / $height;
-            
-            // We want to maximize dimensions within constraints
-            // Calculate dimensions two ways and use the larger option
-            
-            // Option 1: Start with max long side (2000px)
-            $option1Width = $width >= $height ? 2000 : round(2000 * $aspectRatio);
-            $option1Height = $width >= $height ? round(2000 / $aspectRatio) : 2000;
-            
-            // Check if short side exceeds 768px
-            if (($width >= $height && $option1Height > 768) || ($height >= $width && $option1Width > 768)) {
-                // Option 2: Start with max short side (768px)
-                $option2Width = $width <= $height ? 768 : round(768 * $aspectRatio);
-                $option2Height = $width <= $height ? round(768 / $aspectRatio) : 768;
-                
-                // Use option 2 (short side constraint)
-                $transformParams['width'] = $option2Width;
-                $transformParams['height'] = $option2Height;
-                
-                Craft::info("Image dimensions constrained by short side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
-            } else {
-                // Use option 1 (long side constraint)
-                $transformParams['width'] = $option1Width;
-                $transformParams['height'] = $option1Height;
-                
-                Craft::info("Image dimensions constrained by long side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
-            }
-            
+        // If width is larger than height and width is larger than 2000px set transform params
+        if ($width > $height && $width > 2000) {
+            $transformParams['width'] = 2000;
+            $transformParams['height'] = 768;
+            $transformParams['mode'] = 'fit';
+        } elseif ($height > $width && $height > 2000) {
+            $transformParams['width'] = 768;
+            $transformParams['height'] = 2000;
             $transformParams['mode'] = 'fit';
         }
+
+        // // Determine short side and long side
+        // $shortSide = min($width, $height);
+        // $longSide = max($width, $height);
+        
+        // // Add dimension constraints if needed - OpenAI requires max 768px for short side, 2000px for long side
+        // if ($shortSide > 768 || $longSide > 2000) {
+        //     // Calculate the aspect ratio
+        //     $aspectRatio = $width / $height;
+            
+        //     // We want to maximize dimensions within constraints
+        //     // Calculate dimensions two ways and use the larger option
+            
+        //     // Option 1: Start with max long side (2000px)
+        //     $option1Width = $width >= $height ? 2000 : round(2000 * $aspectRatio);
+        //     $option1Height = $width >= $height ? round(2000 / $aspectRatio) : 2000;
+            
+        //     // Check if short side exceeds 768px
+        //     if (($width >= $height && $option1Height > 768) || ($height >= $width && $option1Width > 768)) {
+        //         // Option 2: Start with max short side (768px)
+        //         $option2Width = $width <= $height ? 768 : round(768 * $aspectRatio);
+        //         $option2Height = $width <= $height ? round(768 / $aspectRatio) : 768;
+                
+        //         // Use option 2 (short side constraint)
+        //         $transformParams['width'] = $option2Width;
+        //         $transformParams['height'] = $option2Height;
+                
+        //         Craft::info("Image dimensions constrained by short side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
+        //     } else {
+        //         // Use option 1 (long side constraint)
+        //         $transformParams['width'] = $option1Width;
+        //         $transformParams['height'] = $option1Height;
+                
+        //         Craft::info("Image dimensions constrained by long side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
+        //     }
+            
+        //     $transformParams['mode'] = 'fit';
+        // }
 
         // Very unlikely a 20MB file will be under 2000x768, but just in case lets set the quality to 75 to mitigate the risk of that scenario
         if (empty($transformParams) && $asset->size >  20 * 1024 * 1024) {

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -250,54 +250,16 @@ class OpenAiService extends Component
         }
 
         // If width is larger than height and width is larger than 2000px set transform params
-        if ($width > $height && $width > 2000) {
+        if ($width > $height && ($width > 2000 || $height > 768)) {
             $transformParams['width'] = 2000;
             $transformParams['height'] = 768;
             $transformParams['mode'] = 'fit';
-        } elseif ($height > $width && $height > 2000) {
+        } elseif ($height > $width && ($height > 2000 || $width > 768)) {
             $transformParams['width'] = 768;
             $transformParams['height'] = 2000;
             $transformParams['mode'] = 'fit';
         }
-
-        // // Determine short side and long side
-        // $shortSide = min($width, $height);
-        // $longSide = max($width, $height);
         
-        // // Add dimension constraints if needed - OpenAI requires max 768px for short side, 2000px for long side
-        // if ($shortSide > 768 || $longSide > 2000) {
-        //     // Calculate the aspect ratio
-        //     $aspectRatio = $width / $height;
-            
-        //     // We want to maximize dimensions within constraints
-        //     // Calculate dimensions two ways and use the larger option
-            
-        //     // Option 1: Start with max long side (2000px)
-        //     $option1Width = $width >= $height ? 2000 : round(2000 * $aspectRatio);
-        //     $option1Height = $width >= $height ? round(2000 / $aspectRatio) : 2000;
-            
-        //     // Check if short side exceeds 768px
-        //     if (($width >= $height && $option1Height > 768) || ($height >= $width && $option1Width > 768)) {
-        //         // Option 2: Start with max short side (768px)
-        //         $option2Width = $width <= $height ? 768 : round(768 * $aspectRatio);
-        //         $option2Height = $width <= $height ? round(768 / $aspectRatio) : 768;
-                
-        //         // Use option 2 (short side constraint)
-        //         $transformParams['width'] = $option2Width;
-        //         $transformParams['height'] = $option2Height;
-                
-        //         Craft::info("Image dimensions constrained by short side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
-        //     } else {
-        //         // Use option 1 (long side constraint)
-        //         $transformParams['width'] = $option1Width;
-        //         $transformParams['height'] = $option1Height;
-                
-        //         Craft::info("Image dimensions constrained by long side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
-        //     }
-            
-        //     $transformParams['mode'] = 'fit';
-        // }
-
         // Very unlikely a 20MB file will be under 2000x768, but just in case lets set the quality to 75 to mitigate the risk of that scenario
         if (empty($transformParams) && $asset->size >  20 * 1024 * 1024) {
             Craft::info("$asset->filename is 20MB file detected setting transform quality to 75", __METHOD__);

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -264,8 +264,8 @@ class OpenAiService extends Component
                 $transformParams['height'] = min(round($transformParams['width'] / $aspectRatio), 2000);
             } else {
                 // Landscape: height is the short side
-                $transformParams['width'] = min(round($transformParams['height'] * $aspectRatio), 2000);
                 $transformParams['height'] = min($height, 768);
+                $transformParams['width'] = min(round($transformParams['height'] * $aspectRatio), 2000);
             }
             $transformParams['mode'] = 'fit';
         }

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -264,14 +264,15 @@ class OpenAiService extends Component
                 $transformParams['height'] = min(round($transformParams['width'] / $aspectRatio), 2000);
             } else {
                 // Landscape: height is the short side
-                $transformParams['height'] = min($height, 768);
                 $transformParams['width'] = min(round($transformParams['height'] * $aspectRatio), 2000);
+                $transformParams['height'] = min($height, 768);
             }
             $transformParams['mode'] = 'fit';
         }
 
         // Very unlikely a 20MB file will be under 2000x768, but just in case lets set the quality to 75 to mitigate the risk of that scenario
-        if ($asset->getSize() > 20 * 1024 * 1024) {
+        if (empty($transformParams) && $asset->size >  20 * 1024 * 1024) {
+            Craft::info("$asset->filename is 20MB file detected setting transform quality to 75", __METHOD__);
             $transformParams['quality'] = 75;
         }
 

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -286,13 +286,13 @@ class OpenAiService extends Component
 
         // If no public URL is available or URL is not accessible, try to get the file contents and encode as base64
         if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
-            if ($needsFormatConversion) {
-                // See https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148
-                throw new Exception("Asset $asset->filename has no URL and an unsupported MIME type \"$assetMimeType\". A transform is required but retrieving the file contents for a transform is unsupported.");
-            }
-            if (!empty($transformParams)) {
-                throw new Exception("Asset $asset->filename has no URL and requires a transform, but retrieving the file contents for a transform is unsupported.");
-            }
+            // if ($needsFormatConversion) {
+            //     // See https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148
+            //     throw new Exception("Asset $asset->filename has no URL and an unsupported MIME type \"$assetMimeType\". A transform is required but retrieving the file contents for a transform is unsupported.");
+            // }
+            // if (!empty($transformParams)) {
+            //     throw new Exception("Asset $asset->filename has no URL and requires a transform, but retrieving the file contents for a transform is unsupported.");
+            // }
             $assetContents = $asset->getContents();
 
             // Encode as base64 and create data URI

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -258,15 +258,32 @@ class OpenAiService extends Component
             // Calculate the aspect ratio
             $aspectRatio = $width / $height;
             
-            if ($width <= $height) {
-                // Portrait or square: width is the short side
-                $transformParams['width'] = min($width, 768);
-                $transformParams['height'] = min(round($transformParams['width'] / $aspectRatio), 2000);
+            // We want to maximize dimensions within constraints
+            // Calculate dimensions two ways and use the larger option
+            
+            // Option 1: Start with max long side (2000px)
+            $option1Width = $width >= $height ? 2000 : round(2000 * $aspectRatio);
+            $option1Height = $width >= $height ? round(2000 / $aspectRatio) : 2000;
+            
+            // Check if short side exceeds 768px
+            if (($width >= $height && $option1Height > 768) || ($height >= $width && $option1Width > 768)) {
+                // Option 2: Start with max short side (768px)
+                $option2Width = $width <= $height ? 768 : round(768 * $aspectRatio);
+                $option2Height = $width <= $height ? round(768 / $aspectRatio) : 768;
+                
+                // Use option 2 (short side constraint)
+                $transformParams['width'] = $option2Width;
+                $transformParams['height'] = $option2Height;
+                
+                Craft::info("Image dimensions constrained by short side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
             } else {
-                // Landscape: height is the short side
-                $transformParams['height'] = min($height, 768);
-                $transformParams['width'] = min(round($transformParams['height'] * $aspectRatio), 2000);
+                // Use option 1 (long side constraint)
+                $transformParams['width'] = $option1Width;
+                $transformParams['height'] = $option1Height;
+                
+                Craft::info("Image dimensions constrained by long side: {$transformParams['width']}x{$transformParams['height']}", __METHOD__);
             }
+            
             $transformParams['mode'] = 'fit';
         }
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -40,7 +40,7 @@
     </thead>
     <tbody>
         <tr class="totalcount">
-            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ sites|first.name }} {% endif %}</strong></td>
+            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ (sites|first).name }} {% endif %}</strong></td>
             <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -40,7 +40,7 @@
     </thead>
     <tbody>
         <tr class="totalcount">
-            <td><strong>All Sites</strong></td>
+            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ sites[0].name }} {% endif %}</strong></td>
             <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -40,7 +40,7 @@
     </thead>
     <tbody>
         <tr class="totalcount">
-            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ sites[0].name }} {% endif %}</strong></td>
+            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ sites|first.name }} {% endif %}</strong></td>
             <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>


### PR DESCRIPTION
- Update some thrown exceptions to instead become Craft wanings, turns out the API may accept other files anyway!
- Adding new test & exception for private assets with no url and unsupported mime type which cannot be transformed
- Adding test to check file size is under 20MB API limit, in super unlikely scenario where it is larger and within the required dimensions perform a transform where quality is reduced further
- Adding new test & exception for private assets with no url but require a transform as Craft does not support retreiving file contents for transforms
- Adding limitations to readme
- Update logic to support new API dimensions limitation "768px (short side) x 2000px (long side)"
- Update all queue job titles, notices and errors to only contain site ID if there is more than 1 Site
- Update bulk actions table to only show 1 "total" row where there is only 1 site