### PR TITLE
dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for AI Alt Text
 
+## 1.5.6-unreleased
+- Fixed issue where running **Generate all** or **Generate missing** bulk actions could generate alt text for each site **Save translated results for each site** setting was enabled
+
 ## 1.5.5 - 2025-05-16
 
 - Update some thrown exceptions to instead become Craft wanings, turns out the API may accept other files anyway!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for AI Alt Text
 
-## 1.5.6-unreleased
+## 1.5.6 - 2025-05-17
+
 - Fixed issue where running **Generate all** or **Generate missing** bulk actions could generate alt text for each site **Save translated results for each site** setting was enabled
 
 ## 1.5.5 - 2025-05-16

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -89,7 +89,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Image Detail Level** | How detailed the image analysis should be. | `low` |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. | `false` |
 | **Generate for new assets** | Whether to automatically generate alt text when new assets are created. | `false` |
-| **Save Translated Results to Each Site** | Whether to save translated results to an Asset's translatable alt text field for each Site. | `false` |
+| **Save Translated Results to Each site** | Whether to save translated results to an Asset's translatable alt text field for each site. | `false` |
 
 #### 🧠 Model Options
 Some models that support vision capabilities:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Image Detail Level** | How detailed the image analysis should be. | `low` |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. | `false` |
 | **Generate for new assets** | Whether to automatically generate alt text when new assets are created. | `false` |
-| **Save Translated Results to Each Site** | Whether to save translated results to an Asset's translatable alt text field for each Site. | `false` |
+| **Save Translated Results to Each site** | Whether to save translated results to an Asset's translatable alt text field for each site. | `false` |
 
 #### 🧠 Model Options
 Some models that support vision capabilities:

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -156,7 +156,7 @@ class GenerateController extends Controller
                             Craft::info('Queuing alt text generation for asset: ' . $asset->id . ' (' . $asset->filename . ') in site ' . $site->name, __METHOD__);
                             
                             // Create a job for the asset
-                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id);
+                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
                         } catch (\Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);
@@ -283,7 +283,7 @@ class GenerateController extends Controller
                             Craft::info('Queuing alt text generation for asset: ' . $asset->id . ' (' . $asset->filename . ') in site ' . $site->name, __METHOD__);
                             
                             // Set force regeneration to true to regenerate all assets
-                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id, false, true);
+                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
                         } catch (\Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -43,7 +43,7 @@ class AiAltTextService extends Component
      * @param bool $skipExistingJobCheck Whether to skip the check for existing jobs (useful for bulk operations)
      * @param bool $forceRegeneration Whether to force regeneration even if alt text exists
      */
-    public function createJob(Asset $asset, $saveCurrentSiteOffQueue = false, $currentSiteId = null, $skipExistingJobCheck = false, $forceRegeneration = false): void
+    public function createJob(Asset $asset, $saveCurrentSiteOffQueue = false, $currentSiteId = null, $skipExistingJobCheck = false, $forceRegeneration = false, $skipSaveTranslatedResultsToEachSiteSetting = false): void
     {
         $queue = Craft::$app->getQueue();
 
@@ -78,7 +78,7 @@ class AiAltTextService extends Component
         }
 
         // Get the $saveTranslatedResultsToEachSite setting value
-        $saveTranslatedResultsToEachSite = AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;;
+        $saveTranslatedResultsToEachSite = $skipSaveTranslatedResultsToEachSiteSetting ? false : AiAltText::getInstance()->settings->saveTranslatedResultsToEachSite;
 
         // Check if we need to save the current site off queue
         if ($saveCurrentSiteOffQueue) {

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -24,9 +24,7 @@
 
 <h2>Bulk actions</h2>
 
-<p>Generate alt text for all assets</p>
-
-<p>⚠️ These actions will generate alt text for all assets on a single site or for all sites, even if the <strong>Save translated results for each site</strong> setting is enabled.</p>
+<p>Generate alt text for all assets, the <strong>Save translated results for each site</strong> setting will be ignored to perform the requested action.</p>
 
 <table class="data fullwidth">
     <thead>

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -26,7 +26,7 @@
 
 <p>Generate alt text for all assets</p>
 
-<p>⚠️ These actions can generate alt text for all assets on a single Site or all Sites, even if the <strong>Save translated results for each Site</strong> setting is disabled.</p>
+<p>⚠️ These actions can generate alt text for all assets on a single site or all sites, even if the <strong>Save translated results for each site</strong> setting is disabled.</p>
 
 <table class="data fullwidth">
     <thead>
@@ -40,7 +40,7 @@
     </thead>
     <tbody>
         <tr class="totalcount">
-            <td><strong>{% if sites|length > 1 %} All Sites {% else %} {{ (sites|first).name }} {% endif %}</strong></td>
+            <td><strong>{% if sites|length > 1 %} All sites {% else %} {{ (sites|first).name }} {% endif %}</strong></td>
             <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithAltTextForAllSites }}</td>
             <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>
@@ -135,10 +135,10 @@
 }) }}
 
 {{ forms.lightswitchField({
-    label: 'Save translated results for each Site'|t('aialttext'),
+    label: 'Save translated results for each site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',
-    instructions: "If enabled, the plugin will queue an extra job for each Craft Site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the Craft Site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, alt text will generate for assets on the current Site."|t("aialttext"),
+    instructions: "If enabled, the plugin will queue an extra job for each site using related content e.g. where `{site.language}` is used in the prompt it will be replaced with the assigned language of the site (`en-GB` for British english, `en-US` for American english, `de` for German etc). When disabled, alt text will generate for assets on the current site."|t("aialttext"),
     on: settings.saveTranslatedResultsToEachSite,
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -26,7 +26,7 @@
 
 <p>Generate alt text for all assets</p>
 
-<p>⚠️ These actions can generate alt text for all assets on a single site or all sites, even if the <strong>Save translated results for each site</strong> setting is disabled.</p>
+<p>⚠️ These actions will generate alt text for all assets on a single site or for all sites, even if the <strong>Save translated results for each site</strong> setting is enabled.</p>
 
 <table class="data fullwidth">
     <thead>


### PR DESCRIPTION
- **Update CHANGELOG.md to document the fix for bulk action alt text generation issue when saving translated results is enabled. Revise PLUGIN_STORE_README.md and README.md for consistency in terminology regarding asset settings. Adjust _settings.twig for uniformity in site naming conventions.**
- **Enhance logging for alt text generation in GenerateController.php by adding detailed info and error messages for asset queuing. This improves debugging and tracking of asset processing across sites.**
- **Refactor AiAltTextService.php to enhance clarity in method parameters and improve comments for better understanding of job creation logic, particularly regarding site settings and bulk operations.**
- **Update _settings.twig to clarify alt text generation actions, specifying that they will generate alt text for all assets on a single site or all sites, even if the 'Save translated results' setting is enabled.**
- **Update _settings.twig to enhance clarity on bulk actions for alt text generation, specifying that the 'Save translated results for each site' setting will be ignored during the process.**
