### PR TITLE
feature/claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Updated shared logic for image transformation and base64 encoding across providers
 - Updated error handling for API request failures and asset accessibility checks
 - Updated settings page instructions to be more clear
+- Fixed bug where alt text would propagate across sites despite propagate setting being disabled
 
 ## 1.6.2 - 2025-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Updated plugin services to be registered as plugin components so we can access via the plugin instance rather than via instantiating each time we require them.
 - Updated all request/response model class property casing to use camelcase instead of snake case
 - Updated request models to no longer use a method to progressively build the payload on each setter
+- Updated default prompt in readme and settings to be more concise and direct for intended purpose, to not assuming gender, and to avoid random prefixes.
 - Fixed bug where alt text would propagate across sites despite propagate setting being disabled
 - Fixed TypeError in OpenAI error handling where a non-array error response would crash `parseResponse()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes for AI Alt Text
 
+## UNRELEASED
+
+- Adding functionality to support a new AI Provider (Anthropic Claude)
+- Adding new setting field to choose AI Provider
+- Adding new settings template logic to show/hide relevant AI provider settings fields (e.g. model and api keys)
+- Migrating bulk actions to the CraftCMS Dashboard utilities area
+
 ## 1.6.2 - 2025-08-19
 
 - Updating default model to be `gpt-5-nano`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## UNRELEASED
 
-- Adding functionality to support a new AI Provider (Anthropic Claude) via the Messages API
-- Adding automatic image scaling for Anthropic Claude to account for 5MB file limits and 1600 token area limits
+- Adding functionality to support a new AI Provider (Anthropic) via the Messages API
+- Adding image scaling for Anthropic to account for 5MB file limits and 1600 token area limits
 - Adding new setting field to choose AI Provider (OpenAI or Anthropic)
 - Adding new settings template logic to show/hide relevant AI provider settings fields (e.g. model and api keys)
+- Updated image scaling for OpenAI to account for patch budget limits
 - Updated bulk actions table and buttons to be migrated to the CraftCMS Dashboard utilities area for improved performance and visibility
 - Updated shared logic for image transformation and base64 encoding across providers
 - Updated error handling for API request failures and asset accessibility checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,20 @@
 ## UNRELEASED
 
 - Adding functionality to support a new AI Provider (Anthropic) via the Messages API
-- Adding image scaling for Anthropic to account for 5MB file limits and 1600 token area limits
 - Adding new setting field to choose AI Provider (OpenAI or Anthropic)
-- Adding new settings template logic to show/hide relevant AI provider settings fields (e.g. model and api keys)
-- Updated image scaling for OpenAI to account for patch budget limits
+- Adding automatic image scaling for Anthropic to account for 5MB payload limits and pixel area token costs
+- Adding automatic image scaling for OpenAI to account for 20MB payload limits and patch budget constraints
+- Added support for new OpenAI detail levels `original` & `auto` option for OpenAI (gpt-5.4+ models)
 - Updated bulk actions table and buttons to be migrated to the CraftCMS Dashboard utilities area for improved performance and visibility
 - Updated shared logic for image transformation and base64 encoding across providers
 - Updated error handling for API request failures and asset accessibility checks
-- Updated settings page instructions to be more clear
+- Updated settings page setup instructions & field instructions and placeholders to be more clear
+- Updated all use declartions to be grouped if possible
+- Updated plugin services to be registered as plugin components so we can access via the plugin instance rather than via instantiating each time we require them.
+- Updated all request/response model class property casing to use camelcase instead of snake case
+- Updated request models to no longer use a method to progressively build the payload on each setter
 - Fixed bug where alt text would propagate across sites despite propagate setting being disabled
+- Fixed TypeError in OpenAI error handling where a non-array error response would crash `parseResponse()`
 
 ## 1.6.2 - 2025-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## UNRELEASED
 
-- Adding functionality to support a new AI Provider (Anthropic Claude)
-- Adding new setting field to choose AI Provider
+- Adding functionality to support a new AI Provider (Anthropic Claude) via the Messages API
+- Adding automatic image scaling for Anthropic Claude to account for 5MB file limits and 1600 token area limits
+- Adding new setting field to choose AI Provider (OpenAI or Anthropic)
 - Adding new settings template logic to show/hide relevant AI provider settings fields (e.g. model and api keys)
-- Migrating bulk actions to the CraftCMS Dashboard utilities area
+- Updated bulk actions table and buttons to be migrated to the CraftCMS Dashboard utilities area for improved performance and visibility
+- Updated shared logic for image transformation and base64 encoding across providers
+- Updated error handling for API request failures and asset accessibility checks
+- Updated settings page instructions to be more clear
 
 ## 1.6.2 - 2025-08-19
 

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -1,6 +1,6 @@
 # 🤖 💬 AI Alt Text
   
-Generate alt text for CraftCMS Asset Images using OpenAI's API.
+Generate alt text for CraftCMS Asset Images using Anthropic Claude API or the OpenAI API.
 
 [Plugin Store](https://plugins.craftcms.com/ai-alt-text?craft5) | [GitHub Repository](https://github.com/heavymetalavo/craft-aialttext)
 
@@ -13,7 +13,7 @@ Generate alt text for CraftCMS Asset Images using OpenAI's API.
 This plugin requires: 
 - Craft CMS 5.0.0 or later
 - PHP 8.2 or later
-- An OpenAI API key
+- An Anthropic Claude API key or an OpenAI API key
 
 ## 📥 Installation
 
@@ -39,7 +39,16 @@ Then:
 ddev craft plugin/install ai-alt-text
 ```
 
-## 🤖 Setup OpenAI API Key
+## 🤖 Setup API Keys
+
+### Anthropic Claude
+
+1. Visit [https://console.anthropic.com/](https://console.anthropic.com/) and [sign up](https://console.anthropic.com/).
+2. Navigate to **Settings → API Keys**.
+3. Create a new API key and save it to an environment variable (`.env`).
+4. Ensure you have credits in your account under **Billing**.
+
+### OpenAI
 
 1. Visit [https://platform.openai.com/](https://platform.openai.com/) and [sign up](https://platform.openai.com/signup) in the top-right.
 2. Revisit [the API platform home page](https://platform.openai.com/) again
@@ -57,6 +66,173 @@ ddev craft plugin/install ai-alt-text
 3. Ensure your templates are updated to use the `alt` field, you could consider a fallback `asset.alt ?: asset.title` if that what was used before
 4. Then generate some AI Alt text by performing one of the following actions:
     1. Triggering a bulk action in the bulk actions table
+    2. For individual or a group of specific assets find them in the <strong>Assets</strong> manager section</a> clicking the checkbox on a row, clicking the cog icon to reveal the Element actions menu and select <strong>Generate AI Alt Text</strong>
+    3. When viewing a single asset's page, open the action menu and select <strong>Generate AI Alt Text</strong>
+    4. Upload a new asset (if the upload setting is enabled)
+5. The plugin will queue jobs to generate alt text for each selected asset
+
+![The Bulk Actions table in the AI Alt Text settings page](src/bulk-actions.png)
+
+![The CraftCMS assets manager with two assets selected and the 'Generate AI Alt Text' option visible in the active element actions menu](src/assets-manager.png)
+
+![The active actions menu when viewing a single asset shows the 'Generate AI Alt Text' option](src/single-asset.png)
+
+Example twig:
+
+```twig
+{% set asset = craft.assets.one() %}
+<img src="{{ asset.url }}" alt="{{ asset.alt ?: asset.title }}">
+```
+
+## 🖥️ Console Commands
+
+**Important**: These commands will create **queue** jobs which when run will generate the alt text. By default, all commands process **all sites** unless `--site-id` is specified.
+
+### Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `ai-alt-text/generate/stats` | Show alt text coverage statistics |
+| `ai-alt-text/generate/missing` | Queue jobs for assets without alt text (recommended) |
+| `ai-alt-text/generate/all` | Queue jobs for ALL assets (⚠️ overwrites existing alt text) |
+| `ai-alt-text/generate/single <id>` | Queue job for a specific asset ID |
+
+### Options
+
+| Option | Alias | Description | Default |
+|--------|-------|-------------|---------|
+| `--site-id=<id>` | `-s` | Process only specific site (if not set, processes all sites) | * |
+| `--batch-size=<n>` | `-b` | Assets per batch (memory efficiency) | `500` |
+| `--verbose` | `-v` | Show detailed progress | `false` |
+| `--force` | `-f` | Skip confirmations | `false` |
+
+### Examples
+
+```sh
+# Check coverage across all sites
+./craft ai-alt-text/generate/stats
+
+# Queue missing alt text for all sites
+./craft ai-alt-text/generate/missing
+
+# Queue for specific site with verbose output
+./craft ai-alt-text/generate/missing --site-id=2 --verbose
+
+# Queue for single asset
+./craft ai-alt-text/generate/single 123
+```
+
+## ⚙️ Plugin settings
+
+After installation, configure the plugin at **Settings → AI Alt Text**:
+
+### 📊 Settings overview
+
+| Setting | Description |
+|---------|-------------|
+| **AI Provider** | Choose between OpenAI or Anthropic Claude. |
+| **OpenAI/Anthropic API Key** | Your provider's API key. |
+| **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
+| **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
+| **Prompt** | The text prompt sent to the AI providers (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` |
+| **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
+| **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
+| **Save translated results for each site** | Save translated results to translatable fields for each site. |
+
+#### 🧠 Model Options
+
+All vision models should work, these small models seem to hit the sweetspot between quality & cost:
+- `claude-haiku-4-5` - For Claude: "The fastest model with near-frontier intelligence"
+- `gpt-5-nano` - For OpenAI: "Fastest, most cost-efficient version of GPT-5"
+
+To find out which models are capable of vision, check [the models page](https://platform.openai.com/docs/models), click into a model's detail page (e.g., [gpt-5-nano](https://platform.openai.com/docs/models/gpt-5-nano)) and look for "**Input**: Text, image" in the features columns at the top.
+
+#### 💬 Default prompt
+
+> Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}
+
+#### 🔍 Image detail options
+
+**OpenAI:**
+- `low` - Less detailed, faster and cheaper (default)
+- `high` - More detailed, slower and more expensive
+- `auto` - Let OpenAI decide
+
+**Anthropic:**
+- `very_low` - 300px x 300px
+- `low` - 500px x 500px (recommended default)
+- `medium` - 1000px x 1000px
+- `high` - 1568px x 1568px
+
+For more information, refer to the [OpenAI](https://platform.openai.com/docs/guides/images) and [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/vision) documentation.
+
+## 🏷️ Field requirements
+
+This plugin requires a native CraftCMS field for alt text with the handle `alt` to be added to all asset volumes where you want to generate alt text. The plugin will use this field to store the generated alt text.
+
+To add this field:
+1. Go to **Settings → Assets → Volume name → + Add → search for the `alt` field and click → save**
+2. Scroll to Field Layout section
+3. Click the `+ Add` button
+4. Search for the `alt` field and click 
+5. Save changes to the volume
+6. Update your templates to use the new `alt` field
+
+### Provider-Specific Limits
+
+- **Automatic Scaling**: The plugin automatically detects when an image exceeds provider limits and applies transforms (resizing or quality reduction) before sending the payload.
+- **Supported file types**: Both AI providers support: `png`, `jpeg`, `jpg`, `webp`, `gif` (non-animated)
+- **SVG Support**: SVGs are rasterized to PNG (preserving transparency) before being sent to the AI (where transformSvgs is enabled).
+- **Animated GIFs**: Only the first frame is processed.
+- **Private Assets**: Assets on private volumes without public URLs will be sent as base64 encoded strings. Assets which require transform before being base64 encoded are not currently supported by CraftCMS.
+- **Servd/Cloud**: Support for specialized asset bundles (like Servd) depends on the environment's ability to handle raster transforms.
+- **Consider AI Provider level boundaries**: e.g. OpenAI: "No watermarks or logos - No NSFW content - Clear enough for a human to understand"
+
+## Oddities, Logic & Limitations
+
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which over the lifespan of this plugin have changed without notice, the requirements are not always enforced, e.g. base64 encoded images above the required image dimensions have been accepted by the API.
+- Craft CMS uses the [Imagine library](https://github.com/php-imagine/Imagine) for image processing, which can only transform [select image formats](https://github.com/php-imagine/Imagine/blob/develop/src/Image/Format.php#L14-L32). Support for these formats may vary depending on what ImageMagick drivers are available in your environment. If a source image is in a supported format, the plugin will generate a transform in one of the supported file types to send to the OpenAI API.
+- Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
+- The plugin checks a file's mimetype to see if it's valid, or if it needs a format conversion before sending to the API
+- If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
+- If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
+- Where an alternative image transformer is used, e.g. when an application is hosted on [Servd](https://servd.host) and assets are processed through their asset platform this may not support svg -> raster transforms
+
+## 🛠️ Troubleshooting
+
+- If the plugin returns errors about API authentication, verify your API key.
+- For "bad request" errors, ensure your selected model supports vision capabilities.
+- Alt text generation is processed through Craft's queue system for bulk operations, so check the queue if generation seems to be taking a long time.
+- Any errors _should_ be logged, check your queue.log files!
+- Check the asset has a title! If somehow an asset exists without one craft will not be able to resave it.
+
+## ⚠️ Disclaimer
+
+We've taken some steps to try prevent unexpected costs with default plugin settings (e.g. detail: `low` and model: `gpt-5-nano`) though we take no responsibility for excessive API token usage that may result from mistakes, bugs, or security vulnerabilities within this plugin so use at your own risk.
+
+If you are concerned about unexpected charges we recommend:
+- Set up rate limits and spending caps at the API account level in your [OpenAI account settings](https://platform.openai.com/account/billing/limits)
+- Start with smaller batches when using bulk generation until you're comfortable with the costs
+- Consider using the default `low` setting, which significantly reduces token usage
+- Monitor your OpenAI API usage regularly
+
+### 📈 Example usage statistics
+
+When testing with OpenAI using the default settings (`gpt-4o-mini` model, `low` detail level):
+
+| Metric | Value |
+|--------|-------|
+| March budget | $0.03 / $120 |
+| Total tokens used | 163,713 |
+| Total requests | 29 |
+
+## 🙋 Support
+
+If you encounter any issues or have questions, please submit them on [GitHub](https://github.com/heavymetalavo/craft-aialttext/issues).
+
+## Credits
+
+The eye icon used in this project is from [SVG Repo](https://www.svgrepo.com/svg/193488/eye) and is available under the CC0 1.0 Universal (Public Domain) license.
     2. For individual or a group of specific assets find them in the <strong>Assets</strong> manager section</a> clicking the checkbox on a row, clicking the cog icon to reveal the Element actions menu and select <strong>Generate AI Alt Text</strong>
     3. When viewing a single asset's page, open the action menu and select <strong>Generate AI Alt Text</strong>
     4. Upload a new asset (if the upload setting is enabled)

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -149,7 +149,7 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
 
 #### 🔍 Image detail options
 
@@ -320,7 +320,7 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
 
 #### 🔍 Image detail options
 - `low` - Less detailed, faster and cheaper (default to protect against unexpected costs)

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -320,7 +320,7 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
 
 #### 🔍 Image detail options
 - `low` - Less detailed, faster and cheaper (default to protect against unexpected costs)

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -1,6 +1,6 @@
 # 🤖 💬 AI Alt Text
   
-Generate alt text for CraftCMS Asset Images using Anthropic Claude API or the OpenAI API.
+Generate alt text for CraftCMS Asset Images using the Anthropic or OpenAI API.
 
 [Plugin Store](https://plugins.craftcms.com/ai-alt-text?craft5) | [GitHub Repository](https://github.com/heavymetalavo/craft-aialttext)
 
@@ -13,7 +13,7 @@ Generate alt text for CraftCMS Asset Images using Anthropic Claude API or the Op
 This plugin requires: 
 - Craft CMS 5.0.0 or later
 - PHP 8.2 or later
-- An Anthropic Claude API key or an OpenAI API key
+- An Anthropic API key or an OpenAI API key
 
 ## 📥 Installation
 
@@ -41,7 +41,7 @@ ddev craft plugin/install ai-alt-text
 
 ## 🤖 Setup API Keys
 
-### Anthropic Claude
+### Anthropic
 
 1. Visit [https://console.anthropic.com/](https://console.anthropic.com/) and [sign up](https://console.anthropic.com/).
 2. Navigate to **Settings → API Keys**.
@@ -130,7 +130,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 
 | Setting | Description |
 |---------|-------------|
-| **AI Provider** | Choose between OpenAI or Anthropic Claude. |
+| **AI Provider** | Choose between OpenAI or Anthropic. |
 | **OpenAI/Anthropic API Key** | Your provider's API key. |
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
@@ -142,7 +142,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 #### 🧠 Model Options
 
 All vision models should work, these small models seem to hit the sweetspot between quality & cost:
-- `claude-haiku-4-5` - For Claude: "The fastest model with near-frontier intelligence"
+- `claude-haiku-4-5` - For Anthropic: "The fastest model with near-frontier intelligence"
 - `gpt-5-nano` - For OpenAI: "Fastest, most cost-efficient version of GPT-5"
 
 To find out which models are capable of vision, check [the models page](https://platform.openai.com/docs/models), click into a model's detail page (e.g., [gpt-5-nano](https://platform.openai.com/docs/models/gpt-5-nano)) and look for "**Input**: Text, image" in the features columns at the top.

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -154,12 +154,13 @@ To find out which models are capable of vision, check [the models page](https://
 #### 🔍 Image detail options
 
 **OpenAI:**
-- `low` - Less detailed, faster and cheaper (default)
-- `high` - More detailed, slower and more expensive
-- `auto` - Let OpenAI decide
+- `low` - Fast, low-cost (512px x 512px) (default)
+- `high` - Standard high-fidelity understanding
+- `original` - Large, dense, spatially sensitive images (gpt-5.4+)
+- `auto` - Let the model choose
 
 **Anthropic:**
-- `very_low` - 300px x 300px
+- `veryLow` - 300px x 300px
 - `low` - 500px x 500px (recommended default)
 - `medium` - 1000px x 1000px
 - `high` - 1568px x 1568px

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -154,14 +154,13 @@ To find out which models are capable of vision, check [the models page](https://
 #### 🔍 Image detail options
 
 **OpenAI:**
-- `low` - Fast, low-cost (512px x 512px) (default)
+- `low` - Fast, low-cost (512px x 512px) (recommended)
 - `high` - Standard high-fidelity understanding
 - `original` - Large, dense, spatially sensitive images (gpt-5.4+)
 - `auto` - Let the model choose
 
 **Anthropic:**
-- `veryLow` - 300px x 300px
-- `low` - 500px x 500px (recommended default)
+- `low` - 500px x 500px (recommended)
 - `medium` - 1000px x 1000px
 - `high` - 1568px x 1568px
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
 
 #### 🔍 Image detail options
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🤖 💬 AI Alt Text
   
-Generate alt text for CraftCMS Asset Images using OpenAI's API.
+Generate alt text for CraftCMS Asset Images using Anthropic Claude or OpenAI API.
 
 [Plugin Store](https://plugins.craftcms.com/ai-alt-text?craft5) | [GitHub Repository](https://github.com/heavymetalavo/craft-aialttext)
 
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/0f7eb3e5-bf33-4f49-a8b8-6579a4c05f8b
 This plugin requires: 
 - Craft CMS 5.0.0 or later
 - PHP 8.2 or later
-- An OpenAI API key
+- An Anthropic Claude API key or an OpenAI API key
 
 ## 📥 Installation
 
@@ -39,7 +39,16 @@ Then:
 ddev craft plugin/install ai-alt-text
 ```
 
-## 🤖 Setup OpenAI API Key
+## 🤖 Setup API Keys
+
+### Anthropic Claude
+
+1. Visit [https://console.anthropic.com/](https://console.anthropic.com/) and [sign up](https://console.anthropic.com/).
+2. Navigate to **Settings → API Keys**.
+3. Create a new API key and save it to an environment variable (`.env`).
+4. Ensure you have credits in your account under **Billing**.
+
+### OpenAI
 
 1. Visit [https://platform.openai.com/](https://platform.openai.com/) and [sign up](https://platform.openai.com/signup) in the top-right.
 2. Revisit [the API platform home page](https://platform.openai.com/) again
@@ -119,22 +128,22 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 
 ### 📊 Settings overview
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **OpenAI API Key** | Your OpenAI API key. You can get one from [OpenAI's API Platform](https://platform.openai.com/api-keys). | None (required) |
-| **Prompt** | The text prompt sent to the AI to generate alt text. Supports `{asset.property}` and `{site.property}` | See below |
-| **Open AI Model** | The OpenAI model to use for generating alt text. | `gpt-5-nano` |
-| **Open AI Image Input Detail Level** | How detailed the image analysis should be. | `low` |
-| **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. | `false` |
-| **Generate for new image assets (on upload)** | Whether to automatically generate alt text when new assets are created. | `false` |
-| **Save translated results for each site** | Whether to save translated results to an Asset's translatable alt text field for each site. | `false` |
+| Setting | Description |
+|---------|-------------|
+| **AI Provider** | Choose between OpenAI or Anthropic Claude. |
+| **OpenAI/Anthropic API Key** | Your provider's API key. |
+| **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
+| **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
+| **Prompt** | The text prompt sent to the AI providers (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` |
+| **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
+| **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
+| **Save translated results for each site** | Save translated results to translatable fields for each site. |
 
 #### 🧠 Model Options
-Some models that support vision capabilities:
-- `gpt-5-nano` - Fast, most affordable small model for focused tasks (default)
-- `gpt-4.1-nano` - Fast, affordable small model for focused tasks
-- `gpt-4o` - Fast, intelligent, flexible GPT model
-- `o1` - High-intelligence reasoning model
+
+All vision models should work, these small models seem to hit the sweetspot between quality & cost:
+- `claude-haiku-4-5` - For Claude: "The fastest model with near-frontier intelligence"
+- `gpt-5-nano` - For OpenAI: "Fastest, most cost-efficient version of GPT-5"
 
 To find out which models are capable of vision, check [the models page](https://platform.openai.com/docs/models), click into a model's detail page (e.g., [gpt-5-nano](https://platform.openai.com/docs/models/gpt-5-nano)) and look for "**Input**: Text, image" in the features columns at the top.
 
@@ -143,11 +152,19 @@ To find out which models are capable of vision, check [the models page](https://
 > Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}
 
 #### 🔍 Image detail options
-- `low` - Less detailed, faster and cheaper (default to protect against unexpected costs)
-- `high` - More detailed, slower and more expensive (higher resolution analysis)
+
+**OpenAI:**
+- `low` - Less detailed, faster and cheaper (default)
+- `high` - More detailed, slower and more expensive
 - `auto` - Let OpenAI decide
 
-For more information about these settings, refer to the [OpenAI API documentation](https://platform.openai.com/docs/guides/images).
+**Anthropic:**
+- `very_low` - 300px x 300px
+- `low` - 500px x 500px (recommended default)
+- `medium` - 1000px x 1000px
+- `high` - 1568px x 1568px
+
+For more information, refer to the [OpenAI](https://platform.openai.com/docs/guides/images) and [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/vision) documentation.
 
 ## 🏷️ Field requirements
 
@@ -161,35 +178,25 @@ To add this field:
 5. Save changes to the volume
 6. Update your templates to use the new `alt` field
 
-## Limitations
+### Provider-Specific Limits
 
-- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which have changed in the past month (2025-05), however these requirements don't appear to be enforced, e.g. sending a base64 image above required image dimensions will be accepted by the API.
+- **Automatic Scaling**: The plugin automatically detects when an image exceeds provider limits and applies transforms (resizing or quality reduction) before sending the payload.
+- **Supported file types**: Both AI providers support: `png`, `jpeg`, `jpg`, `webp`, `gif` (non-animated)
+- **SVG Support**: SVGs are rasterized to PNG (preserving transparency) before being sent to the AI (where transformSvgs is enabled).
+- **Animated GIFs**: Only the first frame is processed.
+- **Private Assets**: Assets on private volumes without public URLs will be sent as base64 encoded strings. Assets which require transform before being base64 encoded are not currently supported by CraftCMS.
+- **Servd/Cloud**: Support for specialized asset bundles (like Servd) depends on the environment's ability to handle raster transforms.
+- **Consider AI Provider level boundaries**: e.g. OpenAI: "No watermarks or logos - No NSFW content - Clear enough for a human to understand"
+
+## Oddities, Logic & Limitations
+
+- The OpenAI API has [image input requirements](https://platform.openai.com/docs/guides/images-vision?api-mode=responses#image-input-requirements) which over the lifespan of this plugin have changed without notice, the requirements are not always enforced, e.g. base64 encoded images above the required image dimensions have been accepted by the API.
 - Craft CMS uses the [Imagine library](https://github.com/php-imagine/Imagine) for image processing, which can only transform [select image formats](https://github.com/php-imagine/Imagine/blob/develop/src/Image/Format.php#L14-L32). Support for these formats may vary depending on what ImageMagick drivers are available in your environment. If a source image is in a supported format, the plugin will generate a transform in one of the supported file types to send to the OpenAI API.
 - Where an unsupported file type is requested the plugin will attempt an image transform to a jpg to be sent instead
-- The plugin checks a file's mimetype to see if it's valid, [a filename which contains the wrong extension could return the wrong file type until Craft v5.8.0 is released](https://github.com/craftcms/cms/issues/17246#issuecomment-2873706369)
+- The plugin checks a file's mimetype to see if it's valid, or if it needs a format conversion before sending to the API
 - If an asset's dimensions are larger than the dimensions required by the API an image transform is sent instead
 - If an asset has no URL (private) and requires a transform (e.g. if the original asset is an unsupported mime type, or, the dimensions are too large) the plugin [cannot retrieve the transform's file contents](https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148) to send a base64 encoded version of the image to the OpenAI API.
 - Where an alternative image transformer is used, e.g. when an application is hosted on [Servd](https://servd.host) and assets are processed through their asset platform this may not support svg -> raster transforms
-
-### Supported file types	
-
-- PNG (.png)
-- JPEG (.jpeg and .jpg)
-- WEBP (.webp)
-- Non-animated GIF (.gif)
-
-### Size limits	
-
-- Up to 20MB per image
-- Low-resolution: 512px x 512px
-- High-resolution: 768px (short side) x 2000px (long side)
-
-### Other requirements	
-
-- No watermarks or logos
-- No text
-- No NSFW content
-- Clear enough for a human to understand
 
 ## 🛠️ Troubleshooting
 
@@ -211,7 +218,7 @@ If you are concerned about unexpected charges we recommend:
 
 ### 📈 Example usage statistics
 
-When testing using the default settings (`gpt-4o-mini` model, `low` detail level):
+When testing with OpenAI using the default settings (`gpt-4o-mini` model, `low` detail level):
 
 | Metric | Value |
 |--------|-------|

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
 
 #### 🔍 Image detail options
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ To find out which models are capable of vision, check [the models page](https://
 - `auto` - Let the model choose
 
 **Anthropic:**
-- `veryLow` - 300px x 300px
 - `low` - 500px x 500px (recommended default)
 - `medium` - 1000px x 1000px
 - `high` - 1568px x 1568px

--- a/README.md
+++ b/README.md
@@ -154,12 +154,13 @@ To find out which models are capable of vision, check [the models page](https://
 #### 🔍 Image detail options
 
 **OpenAI:**
-- `low` - Less detailed, faster and cheaper (default)
-- `high` - More detailed, slower and more expensive
-- `auto` - Let OpenAI decide
+- `low` - Fast, low-cost (512px x 512px) (default)
+- `high` - Standard high-fidelity understanding
+- `original` - Large, dense, spatially sensitive images (gpt-5.4+)
+- `auto` - Let the model choose
 
 **Anthropic:**
-- `very_low` - 300px x 300px
+- `veryLow` - 300px x 300px
 - `low` - 500px x 500px (recommended default)
 - `medium` - 1000px x 1000px
 - `high` - 1568px x 1568px

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🤖 💬 AI Alt Text
   
-Generate alt text for CraftCMS Asset Images using Anthropic Claude or OpenAI API.
+Generate alt text for CraftCMS Asset Images using the Anthropic or OpenAI API.
 
 [Plugin Store](https://plugins.craftcms.com/ai-alt-text?craft5) | [GitHub Repository](https://github.com/heavymetalavo/craft-aialttext)
 
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/0f7eb3e5-bf33-4f49-a8b8-6579a4c05f8b
 This plugin requires: 
 - Craft CMS 5.0.0 or later
 - PHP 8.2 or later
-- An Anthropic Claude API key or an OpenAI API key
+- An Anthropic API key or an OpenAI API key
 
 ## 📥 Installation
 
@@ -41,7 +41,7 @@ ddev craft plugin/install ai-alt-text
 
 ## 🤖 Setup API Keys
 
-### Anthropic Claude
+### Anthropic
 
 1. Visit [https://console.anthropic.com/](https://console.anthropic.com/) and [sign up](https://console.anthropic.com/).
 2. Navigate to **Settings → API Keys**.
@@ -130,7 +130,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 
 | Setting | Description |
 |---------|-------------|
-| **AI Provider** | Choose between OpenAI or Anthropic Claude. |
+| **AI Provider** | Choose between OpenAI or Anthropic. |
 | **OpenAI/Anthropic API Key** | Your provider's API key. |
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
@@ -142,7 +142,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 #### 🧠 Model Options
 
 All vision models should work, these small models seem to hit the sweetspot between quality & cost:
-- `claude-haiku-4-5` - For Claude: "The fastest model with near-frontier intelligence"
+- `claude-haiku-4-5` - For Anthropic: "The fastest model with near-frontier intelligence"
 - `gpt-5-nano` - For OpenAI: "Fastest, most cost-efficient version of GPT-5"
 
 To find out which models are capable of vision, check [the models page](https://platform.openai.com/docs/models), click into a model's detail page (e.g., [gpt-5-nano](https://platform.openai.com/docs/models/gpt-5-nano)) and look for "**Input**: Text, image" in the features columns at the top.

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -14,6 +14,9 @@ use craft\web\UrlManager;
 use heavymetalavo\craftaialttext\elements\actions\GenerateAiAltText;
 use heavymetalavo\craftaialttext\services\AiAltTextService;
 use heavymetalavo\craftaialttext\models\Settings;
+use heavymetalavo\craftaialttext\utilities\AiAltTextUtility;
+use craft\services\Utilities;
+use craft\events\RegisterComponentTypesEvent;
 use yii\base\Event;
 use craft\events\RegisterUrlRulesEvent;
 use craft\helpers\Cp;
@@ -117,6 +120,15 @@ class AiAltText extends Plugin
                 }
             }
         );
+
+        // Register Utility
+        Event::on(
+            Utilities::class,
+            Utilities::EVENT_REGISTER_UTILITIES,
+            function(RegisterComponentTypesEvent $event) {
+                $event->types[] = AiAltTextUtility::class;
+            }
+        );
     }
 
     /**
@@ -132,84 +144,10 @@ class AiAltText extends Plugin
      */
     protected function settingsHtml(): ?string
     {
-        // Get current site
-        $currentSite = Craft::$app->getSites()->getCurrentSite();
-        $sites = Craft::$app->getSites()->getAllSites();
-        
-        // Initialize totals
-        $totalAssetsWithAltTextForAllSites = 0;
-        $totalAssetsWithoutAltTextForAllSites = 0;
-        $siteAltTextCounts = [];
-        
-        // Efficiently count assets using database queries (no memory loading)
-        foreach ($sites as $site) {
-            $siteAltTextCounts[$site->id] = [
-                'total' => 0,
-                'with' => 0,
-                'without' => 0
-            ];
-
-            try {
-                // Count total image assets for this site (using count query, not loading assets)
-                $totalImageAssets = Asset::find()
-                    ->kind(Asset::KIND_IMAGE)
-                    ->siteId($site->id)
-                    ->status(null)
-                    ->count();
-                
-                // Count assets WITH alt text using database query
-                $withAltCount = Asset::find()
-                    ->kind(Asset::KIND_IMAGE)
-                    ->siteId($site->id)
-                    ->status(null)
-                    ->where(['not', ['alt' => null]])
-                    ->andWhere(['not', ['alt' => '']])
-                    ->count();
-                
-                // Calculate assets without alt text
-                $withoutAltCount = $totalImageAssets - $withAltCount;
-                
-                // Store counts for this site
-                $siteAltTextCounts[$site->id] = [
-                    'total' => $totalImageAssets,
-                    'with' => $withAltCount,
-                    'without' => $withoutAltCount
-                ];
-                
-                // Add to totals
-                $totalAssetsWithAltTextForAllSites += $withAltCount;
-                $totalAssetsWithoutAltTextForAllSites += $withoutAltCount;
-                
-                Craft::info("Site {$site->name}: Total: {$totalImageAssets}, With Alt: {$withAltCount}, Without Alt: {$withoutAltCount}", __METHOD__);
-            } catch (\Exception $e) {
-                Craft::error("Error counting assets for site {$site->name}: " . $e->getMessage(), __METHOD__);
-                
-                // Set safe defaults on error
-                $siteAltTextCounts[$site->id] = [
-                    'total' => 0,
-                    'with' => 0,
-                    'without' => 0
-                ];
-            }
-        }
-        
-        // For backward compatibility with the template
-        $totalAssets = $siteAltTextCounts[$currentSite->id]['total'] ?? 0;
-        $totalAssetsWithAltText = $siteAltTextCounts[$currentSite->id]['with'] ?? 0;
-        $totalAssetsWithoutAltText = $siteAltTextCounts[$currentSite->id]['without'] ?? 0;
-        
         return Craft::$app->view->renderTemplate(
             'ai-alt-text/_settings',
             [
                 'settings' => $this->getSettings(),
-                'totalAssets' => $totalAssets,
-                'totalAssetsWithAltText' => $totalAssetsWithAltText,
-                'totalAssetsWithoutAltText' => $totalAssetsWithoutAltText,
-                'totalAssetsWithAltTextForAllSites' => $totalAssetsWithAltTextForAllSites,
-                'totalAssetsWithoutAltTextForAllSites' => $totalAssetsWithoutAltTextForAllSites,
-                'currentSite' => $currentSite,
-                'sites' => $sites,
-                'siteAltTextCounts' => $siteAltTextCounts,
             ]
         );
     }

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -6,29 +6,24 @@ use Craft;
 use craft\base\Element;
 use craft\base\Plugin;
 use craft\elements\Asset;
-use craft\events\ModelEvent;
-use craft\events\RegisterElementActionsEvent;
-use craft\events\DefineMenuItemsEvent;
-use craft\web\View;
-use craft\web\UrlManager;
-use heavymetalavo\craftaialttext\elements\actions\GenerateAiAltText;
-use heavymetalavo\craftaialttext\services\AiAltTextService;
-use heavymetalavo\craftaialttext\models\Settings;
-use heavymetalavo\craftaialttext\utilities\AiAltTextUtility;
-use craft\services\Utilities;
-use craft\events\RegisterComponentTypesEvent;
-use yii\base\Event;
-use craft\events\RegisterUrlRulesEvent;
+use craft\events\{ModelEvent, RegisterElementActionsEvent, DefineMenuItemsEvent, RegisterComponentTypesEvent, RegisterUrlRulesEvent};
 use craft\helpers\Cp;
+use craft\services\Utilities;
+use craft\web\{View, UrlManager};
+use heavymetalavo\craftaialttext\elements\actions\GenerateAiAltText;
+use heavymetalavo\craftaialttext\models\Settings;
+use heavymetalavo\craftaialttext\services\{AiAltTextService, OpenAiService, AnthropicService};
+use heavymetalavo\craftaialttext\utilities\AiAltTextUtility;
+use yii\base\Event;
 
 /**
  * AI Alt Text Plugin
  *
- * A Craft CMS plugin that generates alt text for images using OpenAI's vision models.
- * This plugin provides functionality to automatically generate descriptive alt text
- * for images in the Craft CMS asset library.
+ * A Craft CMS plugin that generates alt text for images using AI vision models.
  *
  * @property AiAltTextService $aiAltTextService The service for generating alt text
+ * @property OpenAiService $openAiService
+ * @property AnthropicService $anthropicService
  * @property Settings $settings The plugin settings
  */
 class AiAltText extends Plugin
@@ -39,7 +34,11 @@ class AiAltText extends Plugin
     public static function config(): array
     {
         return [
-            'components' => ['aiAltTextService' => AiAltTextService::class],
+            'components' => [
+                'aiAltTextService' => AiAltTextService::class,
+                'openAiService' => OpenAiService::class,
+                'anthropicService' => AnthropicService::class,
+            ],
         ];
     }
 
@@ -50,9 +49,10 @@ class AiAltText extends Plugin
     {
         parent::init();
 
-        // Register the service
         $this->setComponents([
             'aiAltTextService' => AiAltTextService::class,
+            'openAiService' => OpenAiService::class,
+            'anthropicService' => AnthropicService::class,
         ]);
 
         // Register template path

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -3,11 +3,10 @@
 namespace heavymetalavo\craftaialttext\controllers;
 
 use Craft;
-use craft\web\Controller;
 use craft\elements\Asset;
-use yii\web\Response;
+use craft\web\Controller;
 use heavymetalavo\craftaialttext\AiAltText;
-use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
+use yii\web\Response;
 
 /**
  * Generate Controller
@@ -75,7 +74,8 @@ class GenerateController extends Controller
         $totalCount = 0;
         $processedCount = 0;
         $queuedCount = 0;
-        $settings = AiAltText::getInstance()->getSettings();
+        $plugin = AiAltText::getInstance();
+        $settings = $plugin->getSettings();
         
         // Check if a specific site ID was provided
         $siteId = $this->request->getParam('siteId');
@@ -150,7 +150,7 @@ class GenerateController extends Controller
                             Craft::info('Queuing alt text generation for asset: ' . $asset->id . ' (' . $asset->filename . ') in site ' . $site->name, __METHOD__);
                             
                             // Create a job for the asset
-                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
+                            $plugin->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
                         } catch (\Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);
@@ -210,7 +210,8 @@ class GenerateController extends Controller
         $totalCount = 0;
         $processedCount = 0;
         $queuedCount = 0;
-        $settings = AiAltText::getInstance()->getSettings();
+        $plugin = AiAltText::getInstance();
+        $settings = $plugin->getSettings();
         
         // Check if a specific site ID was provided
         $siteId = $this->request->getParam('siteId');
@@ -277,7 +278,7 @@ class GenerateController extends Controller
                             Craft::info('Queuing alt text generation for asset: ' . $asset->id . ' (' . $asset->filename . ') in site ' . $site->name, __METHOD__);
                             
                             // Set force regeneration to true to regenerate all assets
-                            AiAltText::getInstance()->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
+                            $plugin->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
                         } catch (\Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -87,7 +87,7 @@ class GenerateController extends Controller
                 Craft::$app->getSession()->setError(
                     Craft::t('ai-alt-text', 'Invalid site ID: {siteId}', ['siteId' => $siteId])
                 );
-                return $this->redirect('settings/plugins/ai-alt-text');
+                return $this->redirect('utilities/ai-alt-text-bulk-actions');
             }
         } else {
             // Otherwise process all sites
@@ -100,10 +100,7 @@ class GenerateController extends Controller
                 $assets = Asset::find()
                     ->kind(Asset::KIND_IMAGE)
                     ->siteId($site->id)
-                    ->andWhere(['or', 
-                        ['alt' => null],
-                        ['alt' => '']
-                    ])
+                    ->hasAlt(false)
                     ->count();
                 
                 $totalCount += $assets;
@@ -126,10 +123,7 @@ class GenerateController extends Controller
                     $assets = Asset::find()
                         ->kind(Asset::KIND_IMAGE)
                         ->siteId($site->id)
-                        ->andWhere(['or', 
-                            ['alt' => null],
-                            ['alt' => '']
-                        ])
+                        ->hasAlt(false)
                         ->offset($offset)
                         ->limit($limit)
                         ->all();
@@ -191,7 +185,7 @@ class GenerateController extends Controller
             }
             
             // Redirect back to settings page
-            return $this->redirect('settings/plugins/ai-alt-text');
+            return $this->redirect('utilities/ai-alt-text-bulk-actions');
         } catch (\Exception $e) {
             Craft::error('Error queueing alt text generation for assets without alt text: ' . $e->getMessage(), __METHOD__);
             
@@ -199,7 +193,7 @@ class GenerateController extends Controller
                 Craft::t('ai-alt-text', 'Error: {message}', ['message' => $e->getMessage()])
             );
             
-            return $this->redirect('settings/plugins/ai-alt-text');
+            return $this->redirect('utilities/ai-alt-text-bulk-actions');
         }
     }
 
@@ -228,7 +222,7 @@ class GenerateController extends Controller
                 Craft::$app->getSession()->setError(
                     Craft::t('ai-alt-text', 'Invalid site ID: {siteId}', ['siteId' => $siteId])
                 );
-                return $this->redirect('settings/plugins/ai-alt-text');
+                return $this->redirect('utilities/ai-alt-text-bulk-actions');
             }
         } else {
             // Otherwise process all sites
@@ -318,7 +312,7 @@ class GenerateController extends Controller
             }
             
             // Redirect back to settings page
-            return $this->redirect('settings/plugins/ai-alt-text');
+            return $this->redirect('utilities/ai-alt-text-bulk-actions');
         } catch (\Exception $e) {
             Craft::error('Error queueing alt text generation for all assets: ' . $e->getMessage(), __METHOD__);
             
@@ -326,7 +320,7 @@ class GenerateController extends Controller
                 Craft::t('ai-alt-text', 'Error: {message}', ['message' => $e->getMessage()])
             );
             
-            return $this->redirect('settings/plugins/ai-alt-text');
+            return $this->redirect('utilities/ai-alt-text-bulk-actions');
         }
     }
 }

--- a/src/migrations/m260312_215324_setting_ai_provider.php
+++ b/src/migrations/m260312_215324_setting_ai_provider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\migrations;
+
+use Craft;
+use craft\db\Migration;
+use heavymetalavo\craftaialttext\AiAltText;
+
+/**
+ * m260312_215324_setting_ai_provider migration.
+ */
+class m260312_215324_setting_ai_provider extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $plugin = AiAltText::getInstance();
+        if ($plugin === null) {
+            return true;
+        }
+
+        $settings = $plugin->getSettings();
+
+        // If provider is not set, but an OpenAI key exists, default to openai
+        if (empty($settings->aiProvider) && !empty($settings->openAiApiKey)) {
+            Craft::info('Migrating AI provider to "openai" based on existing API key.', __METHOD__);
+            Craft::$app->getPlugins()->savePluginSettings($plugin, [
+                'aiProvider' => 'openai'
+            ]);
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m260312_215324_setting_ai_provider cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     /**
      * @var string The prompt template for generating alt text
      */
-    public string $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}';
+    public string $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}';
 
     /**
      * @var string The detail level for image analysis

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -28,7 +28,7 @@ class Settings extends Model
     /**
      * @var string The API provider to use
      */
-    public string $aiProvider = 'anthropic';
+    public string $aiProvider = '';
 
     /**
      * @var string The Anthropic API key
@@ -38,12 +38,12 @@ class Settings extends Model
     /**
      * @var string The Anthropic model to use
      */
-    public string $anthropicModel = 'claude-haiku-4-5';
+    public string $anthropicModel = '';
 
     /**
      * @var string The Anthropic image detail level
      */
-    public string $anthropicImageDetailLevel = 'medium';
+    public string $anthropicImageDetailLevel = '';
 
 
     /**
@@ -54,7 +54,7 @@ class Settings extends Model
     /**
      * @var string The OpenAI model to use, must have vision capabilities
      */
-    public string $openAiModel = 'gpt-5-nano';
+    public string $openAiModel = '';
 
     /**
      * @var string The prompt template for generating alt text
@@ -69,7 +69,7 @@ class Settings extends Model
      * - high: More detailed analysis on higher quality image, more expensive
      * - auto: let the model decide
      */
-    public string $openAiImageInputDetailLevel = 'low';
+    public string $openAiImageInputDetailLevel = '';
 
     /**
      * @var bool Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites.

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     /**
      * @var string The prompt template for generating alt text
      */
-    public string $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}';
+    public string $prompt = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}';
 
     /**
      * @var string The detail level for image analysis

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -3,6 +3,7 @@
 namespace heavymetalavo\craftaialttext\models;
 
 use craft\base\Model;
+use craft\helpers\App;
 
 /**
  * Plugin Settings Model
@@ -96,7 +97,7 @@ class Settings extends Model
             [
                 ['aiProvider'],
                 function($attribute) {
-                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    $val = App::parseEnv($this->$attribute);
                     if (!in_array($val, ['openai', 'anthropic'], true)) {
                         $this->addError($attribute, 'Invalid AI Provider configured.');
                     }
@@ -109,7 +110,7 @@ class Settings extends Model
             [
                 ['claudeImageDetailLevel'],
                 function($attribute) {
-                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    $val = App::parseEnv($this->$attribute);
                     if (!in_array($val, ['very_low', 'low', 'medium', 'high', ''], true)) {
                         $this->addError($attribute, 'Invalid Anthropic Image Detail Level configured.');
                     }
@@ -121,7 +122,7 @@ class Settings extends Model
             [
                 ['openAiImageInputDetailLevel'],
                 function($attribute) {
-                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    $val = App::parseEnv($this->$attribute);
                     if (!in_array($val, ['low', 'high', ''], true)) {
                         $this->addError($attribute, 'Invalid OpenAI Image Input Detail Level configured.');
                     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -16,12 +16,36 @@ use craft\base\Model;
  * @property string $prompt The prompt template for generating alt text
  * @property string $openAiImageInputDetailLevel The detail level for image analysis
  * @property bool $propagate Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites.
- * @property bool $saveTranslatedResultsToEachSite Whether to save the translated result to each Site's Asset's translatable alt text field
  * @property string $translationPromptAppendage The prompt suffix for translated results
  * @property bool $generateForNewAssets Whether to generate alt text for new assets automatically
+ * @property string $aiProvider The API provider to use ('openai', 'anthropic', or 'gemini')
+ * @property string $anthropicApiKey The Anthropic API key
+ * @property string $anthropicModel The Anthropic Model
+ * @property string $anthropicImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
  */
 class Settings extends Model
 {
+    /**
+     * @var string The API provider to use
+     */
+    public string $aiProvider = 'anthropic';
+
+    /**
+     * @var string The Anthropic API key
+     */
+    public string $anthropicApiKey = '';
+
+    /**
+     * @var string The Anthropic model to use
+     */
+    public string $anthropicModel = 'claude-haiku-4-5';
+
+    /**
+     * @var string The Anthropic image detail level
+     */
+    public string $anthropicImageDetailLevel = 'medium';
+
+
     /**
      * @var string The OpenAI API key
      */
@@ -35,7 +59,7 @@ class Settings extends Model
     /**
      * @var string The prompt template for generating alt text
      */
-    public string $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}';
+    public string $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}';
 
     /**
      * @var string The detail level for image analysis
@@ -68,9 +92,14 @@ class Settings extends Model
     public function defineRules(): array
     {
         return [
-            [['openAiApiKey', 'openAiModel', 'prompt'], 'required'],
+            [['aiProvider', 'prompt'], 'required'],
+            [['aiProvider'], 'in', 'range' => ['openai', 'anthropic']],
             ['openAiApiKey', 'string'],
             ['openAiModel', 'string'],
+            ['anthropicApiKey', 'string'],
+            ['anthropicModel', 'string'],
+            ['anthropicImageDetailLevel', 'in', 'range' => ['very_low', 'low', 'medium', 'high']],
+
             ['prompt', 'string'],
             ['openAiImageInputDetailLevel', 'string'],
             ['openAiImageInputDetailLevel', 'in', 'range' => ['low', 'high']],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -44,8 +44,7 @@ class Settings extends Model
     /**
      * @var string The Anthropic image detail level
      */
-    public string $anthropicImageDetailLevel = '';
-
+    public string $anthropicImageDetailLevel = 'low';
 
     /**
      * @var string The OpenAI API key
@@ -70,7 +69,7 @@ class Settings extends Model
      * - high: More detailed analysis on higher quality image, more expensive
      * - auto: let the model decide
      */
-    public string $openAiImageInputDetailLevel = '';
+    public string $openAiImageInputDetailLevel = 'low';
 
     /**
      * @var bool Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites.
@@ -85,7 +84,7 @@ class Settings extends Model
     /**
      * @var bool Whether to generate alt text for new assets automatically
      */
-    public bool $generateForNewAssets = false;
+    public bool $generateForNewAssets = true;
 
     /**
      * @inheritdoc

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -22,7 +22,7 @@ use craft\helpers\App;
  * @property string $aiProvider The API provider to use ('openai', 'anthropic', or 'gemini')
  * @property string $anthropicApiKey The Anthropic API key
  * @property string $anthropicModel The Anthropic Model
- * @property string $anthropicImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
+ * @property string $anthropicImageDetailLevel The Anthropic Image Detail Level ('low', 'medium', 'high')
  */
 class Settings extends Model
 {
@@ -110,7 +110,7 @@ class Settings extends Model
                 ['anthropicImageDetailLevel'],
                 function($attribute) {
                     $val = App::parseEnv($this->$attribute);
-                    if (!in_array($val, ['veryLow', 'low', 'medium', 'high', ''], true)) {
+                    if (!in_array($val, ['low', 'medium', 'high', ''], true)) {
                         $this->addError($attribute, 'Invalid Anthropic Image Detail Level configured.');
                     }
                 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -20,9 +20,9 @@ use craft\helpers\App;
  * @property string $translationPromptAppendage The prompt suffix for translated results
  * @property bool $generateForNewAssets Whether to generate alt text for new assets automatically
  * @property string $aiProvider The API provider to use ('openai', 'anthropic', or 'gemini')
- * @property string $claudeApiKey The Anthropic API key
- * @property string $claudeModel The Anthropic Model
- * @property string $claudeImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
+ * @property string $anthropicApiKey The Anthropic API key
+ * @property string $anthropicModel The Anthropic Model
+ * @property string $anthropicImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
  */
 class Settings extends Model
 {
@@ -34,17 +34,17 @@ class Settings extends Model
     /**
      * @var string The Anthropic API key
      */
-    public string $claudeApiKey = '';
+    public string $anthropicApiKey = '';
 
     /**
      * @var string The Anthropic model to use
      */
-    public string $claudeModel = '';
+    public string $anthropicModel = '';
 
     /**
      * @var string The Anthropic image detail level
      */
-    public string $claudeImageDetailLevel = '';
+    public string $anthropicImageDetailLevel = '';
 
 
     /**
@@ -105,10 +105,10 @@ class Settings extends Model
             ],
             ['openAiApiKey', 'string'],
             ['openAiModel', 'string'],
-            ['claudeApiKey', 'string'],
-            ['claudeModel', 'string'],
+            ['anthropicApiKey', 'string'],
+            ['anthropicModel', 'string'],
             [
-                ['claudeImageDetailLevel'],
+                ['anthropicImageDetailLevel'],
                 function($attribute) {
                     $val = App::parseEnv($this->$attribute);
                     if (!in_array($val, ['very_low', 'low', 'medium', 'high', ''], true)) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -19,9 +19,9 @@ use craft\base\Model;
  * @property string $translationPromptAppendage The prompt suffix for translated results
  * @property bool $generateForNewAssets Whether to generate alt text for new assets automatically
  * @property string $aiProvider The API provider to use ('openai', 'anthropic', or 'gemini')
- * @property string $anthropicApiKey The Anthropic API key
- * @property string $anthropicModel The Anthropic Model
- * @property string $anthropicImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
+ * @property string $claudeApiKey The Anthropic API key
+ * @property string $claudeModel The Anthropic Model
+ * @property string $claudeImageDetailLevel The Anthropic Image Detail Level ('very_low', 'low', 'medium', 'high')
  */
 class Settings extends Model
 {
@@ -33,17 +33,17 @@ class Settings extends Model
     /**
      * @var string The Anthropic API key
      */
-    public string $anthropicApiKey = '';
+    public string $claudeApiKey = '';
 
     /**
      * @var string The Anthropic model to use
      */
-    public string $anthropicModel = '';
+    public string $claudeModel = '';
 
     /**
      * @var string The Anthropic image detail level
      */
-    public string $anthropicImageDetailLevel = '';
+    public string $claudeImageDetailLevel = '';
 
 
     /**
@@ -93,16 +93,40 @@ class Settings extends Model
     {
         return [
             [['aiProvider', 'prompt'], 'required'],
-            [['aiProvider'], 'in', 'range' => ['openai', 'anthropic']],
+            [
+                ['aiProvider'],
+                function($attribute) {
+                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    if (!in_array($val, ['openai', 'anthropic'], true)) {
+                        $this->addError($attribute, 'Invalid AI Provider configured.');
+                    }
+                }
+            ],
             ['openAiApiKey', 'string'],
             ['openAiModel', 'string'],
-            ['anthropicApiKey', 'string'],
-            ['anthropicModel', 'string'],
-            ['anthropicImageDetailLevel', 'in', 'range' => ['very_low', 'low', 'medium', 'high']],
+            ['claudeApiKey', 'string'],
+            ['claudeModel', 'string'],
+            [
+                ['claudeImageDetailLevel'],
+                function($attribute) {
+                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    if (!in_array($val, ['very_low', 'low', 'medium', 'high', ''], true)) {
+                        $this->addError($attribute, 'Invalid Anthropic Image Detail Level configured.');
+                    }
+                }
+            ],
 
             ['prompt', 'string'],
             ['openAiImageInputDetailLevel', 'string'],
-            ['openAiImageInputDetailLevel', 'in', 'range' => ['low', 'high']],
+            [
+                ['openAiImageInputDetailLevel'],
+                function($attribute) {
+                    $val = \craft\helpers\App::parseEnv($this->$attribute);
+                    if (!in_array($val, ['low', 'high', ''], true)) {
+                        $this->addError($attribute, 'Invalid OpenAI Image Input Detail Level configured.');
+                    }
+                }
+            ],
             ['propagate', 'boolean'],
             ['saveTranslatedResultsToEachSite', 'boolean'],
             ['generateForNewAssets', 'boolean'],

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -123,7 +123,7 @@ class Settings extends Model
                 ['openAiImageInputDetailLevel'],
                 function($attribute) {
                     $val = App::parseEnv($this->$attribute);
-                    if (!in_array($val, ['low', 'high', ''], true)) {
+                    if (!in_array($val, ['low', 'high', 'original', 'auto', ''], true)) {
                         $this->addError($attribute, 'Invalid OpenAI Image Input Detail Level configured.');
                     }
                 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -111,7 +111,7 @@ class Settings extends Model
                 ['anthropicImageDetailLevel'],
                 function($attribute) {
                     $val = App::parseEnv($this->$attribute);
-                    if (!in_array($val, ['very_low', 'low', 'medium', 'high', ''], true)) {
+                    if (!in_array($val, ['veryLow', 'low', 'medium', 'high', ''], true)) {
                         $this->addError($attribute, 'Invalid Anthropic Image Detail Level configured.');
                     }
                 }

--- a/src/models/api/AnthropicRequest.php
+++ b/src/models/api/AnthropicRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\models\api;
+
+use craft\base\Model;
+
+/**
+ * Anthropic Request Model
+ *
+ * Represents a request to the Anthropic Messages API.
+ */
+class AnthropicRequest extends Model
+{
+    public string $model = '';
+    public int $max_tokens = 1024;
+    public array $messages = [];
+
+    private string $prompt = '';
+    private ?string $imageUrl = null;
+    private ?array $imageSource = null;
+
+    /**
+     * Sets the prompt text for the request
+     */
+    public function setPrompt(string $prompt): self
+    {
+        $this->prompt = $prompt;
+        $this->buildMessages();
+        return $this;
+    }
+
+    /**
+     * Sets the image URL for the request
+     */
+    public function setImageUrl(string $imageUrl): self
+    {
+        $this->imageUrl = $imageUrl;
+        $this->buildMessages();
+        return $this;
+    }
+
+    /**
+     * Sets the image source content for the request (e.g., base64 string and mime type)
+     */
+    public function setImageSource(array $imageSource): self
+    {
+        $this->imageSource = $imageSource;
+        $this->buildMessages();
+        return $this;
+    }
+
+    /**
+     * Builds the messages array structure from the current properties
+     */
+    private function buildMessages(): void
+    {
+        $content = [];
+
+        $source = $this->imageSource;
+        if (!$source && $this->imageUrl) {
+            $source = [
+                'type' => 'url',
+                'url' => $this->imageUrl
+            ];
+        }
+
+        if ($source) {
+            $content[] = [
+                'type' => 'image',
+                'source' => $source
+            ];
+        }
+
+        if (!empty($this->prompt)) {
+            $content[] = [
+                'type' => 'text',
+                'text' => $this->prompt
+            ];
+        }
+
+        $this->messages = [
+            [
+                'role' => 'user',
+                'content' => $content
+            ]
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function defineRules(): array
+    {
+        return [
+            [['model', 'messages', 'max_tokens'], 'required'],
+            ['model', 'string'],
+            ['max_tokens', 'integer'],
+            ['messages', 'safe'],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(array $fields = [], array $expand = [], $recursive = true): array
+    {
+        return [
+            'model' => $this->model,
+            'max_tokens' => $this->max_tokens,
+            'messages' => $this->messages,
+        ];
+    }
+}

--- a/src/models/api/AnthropicRequest.php
+++ b/src/models/api/AnthropicRequest.php
@@ -12,78 +12,31 @@ use craft\base\Model;
 class AnthropicRequest extends Model
 {
     public string $model = '';
-    public int $max_tokens = 1024;
-    public array $messages = [];
+    public int $maxTokens = 1024;
 
     private string $prompt = '';
     private ?string $imageUrl = null;
     private ?array $imageSource = null;
 
-    /**
-     * Sets the prompt text for the request
-     */
     public function setPrompt(string $prompt): self
     {
         $this->prompt = $prompt;
-        $this->buildMessages();
         return $this;
     }
 
-    /**
-     * Sets the image URL for the request
-     */
     public function setImageUrl(string $imageUrl): self
     {
         $this->imageUrl = $imageUrl;
-        $this->buildMessages();
         return $this;
     }
 
     /**
-     * Sets the image source content for the request (e.g., base64 string and mime type)
+     * Sets the image source content for the request (e.g., base64 data and mime type)
      */
     public function setImageSource(array $imageSource): self
     {
         $this->imageSource = $imageSource;
-        $this->buildMessages();
         return $this;
-    }
-
-    /**
-     * Builds the messages array structure from the current properties
-     */
-    private function buildMessages(): void
-    {
-        $content = [];
-
-        $source = $this->imageSource;
-        if (!$source && $this->imageUrl) {
-            $source = [
-                'type' => 'url',
-                'url' => $this->imageUrl
-            ];
-        }
-
-        if ($source) {
-            $content[] = [
-                'type' => 'image',
-                'source' => $source
-            ];
-        }
-
-        if (!empty($this->prompt)) {
-            $content[] = [
-                'type' => 'text',
-                'text' => $this->prompt
-            ];
-        }
-
-        $this->messages = [
-            [
-                'role' => 'user',
-                'content' => $content
-            ]
-        ];
     }
 
     /**
@@ -92,10 +45,9 @@ class AnthropicRequest extends Model
     public function defineRules(): array
     {
         return [
-            [['model', 'messages', 'max_tokens'], 'required'],
+            [['model', 'maxTokens'], 'required'],
             ['model', 'string'],
-            ['max_tokens', 'integer'],
-            ['messages', 'safe'],
+            ['maxTokens', 'integer'],
         ];
     }
 
@@ -104,10 +56,39 @@ class AnthropicRequest extends Model
      */
     public function toArray(array $fields = [], array $expand = [], $recursive = true): array
     {
+        $content = [];
+
+        $source = $this->imageSource;
+        if (!$source && $this->imageUrl) {
+            $source = [
+                'type' => 'url',
+                'url' => $this->imageUrl,
+            ];
+        }
+
+        if ($source) {
+            $content[] = [
+                'type' => 'image',
+                'source' => $source,
+            ];
+        }
+
+        if (!empty($this->prompt)) {
+            $content[] = [
+                'type' => 'text',
+                'text' => $this->prompt,
+            ];
+        }
+
         return [
             'model' => $this->model,
-            'max_tokens' => $this->max_tokens,
-            'messages' => $this->messages,
+            'max_tokens' => $this->maxTokens,
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => $content,
+                ],
+            ],
         ];
     }
 }

--- a/src/models/api/AnthropicResponse.php
+++ b/src/models/api/AnthropicResponse.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\models\api;
+
+use craft\base\Model;
+use craft\helpers\Json;
+use Exception;
+use Craft;
+
+/**
+ * Anthropic Response Model
+ *
+ * Represents a response from the Anthropic API.
+ */
+class AnthropicResponse extends Model
+{
+    public string $output_text = '';
+    public ?array $content = null;
+    public ?array $error = null;
+    private ?array $rawData = null;
+
+    /**
+     * Parse the API response and populate the model properties
+     */
+    public function parseResponse(string $responseBody): bool
+    {
+        try {
+            $responseData = Json::decode($responseBody);
+            $this->rawData = $responseData;
+
+            $this->output_text = '';
+            $this->content = null;
+            $this->error = null;
+
+            if (isset($responseData['type']) && $responseData['type'] === 'error') {
+                $errorMessage = isset($responseData['error']['message']) 
+                    ? $responseData['error']['message'] 
+                    : Json::encode($responseData['error']);
+                $this->setError($errorMessage, $responseData['error'] ?? null);
+                return false;
+            }
+
+            if (!empty($responseData['content'])) {
+                $this->content = $responseData['content'];
+                foreach ($responseData['content'] as $contentBlock) {
+                    if (isset($contentBlock['type']) && $contentBlock['type'] === 'text') {
+                        $this->output_text = trim($contentBlock['text']);
+                        break;
+                    }
+                }
+            } else {
+                Craft::warning('Could not find content in Anthropic response: ' . Json::encode($responseData), __METHOD__);
+                $this->setError('Could not parse response from Anthropic API.');
+                return false;
+            }
+
+            return $this->validate();
+        } catch (Exception $e) {
+            Craft::error('Failed to parse Anthropic response: ' . $e->getMessage(), __METHOD__);
+            $this->setError('Failed to parse response: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Set an error message on the response
+     */
+    public function setError(string $message, ?array $details = null): void
+    {
+        $this->error = [
+            'message' => $message,
+            'details' => $details,
+        ];
+    }
+
+    /**
+     * Get the raw response data
+     */
+    public function getRawData(): ?array
+    {
+        return $this->rawData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function defineRules(): array
+    {
+        return [
+            ['output_text', 'string'],
+            ['content', 'safe'],
+            ['error', 'safe'],
+        ];
+    }
+
+    /**
+     * Checks if the response contains an error.
+     */
+    public function hasError(): bool
+    {
+        return $this->error !== null;
+    }
+
+    /**
+     * Gets the error message from the response.
+     */
+    public function getErrorMessage(): string
+    {
+        return $this->error['message'] ?? '';
+    }
+
+    /**
+     * Gets the generated text from the response.
+     */
+    public function getText(): string
+    {
+        return $this->output_text;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function toArray(array $fields = [], array $expand = [], $recursive = true): array
+    {
+        $data = parent::toArray($fields, $expand, $recursive);
+
+        if ($this->error) {
+            $data['error'] = $this->error;
+        }
+
+        return $data;
+    }
+}

--- a/src/models/api/AnthropicResponse.php
+++ b/src/models/api/AnthropicResponse.php
@@ -14,7 +14,7 @@ use Craft;
  */
 class AnthropicResponse extends Model
 {
-    public string $output_text = '';
+    public string $outputText = '';
     public ?array $content = null;
     public ?array $error = null;
     private ?array $rawData = null;
@@ -28,7 +28,7 @@ class AnthropicResponse extends Model
             $responseData = Json::decode($responseBody);
             $this->rawData = $responseData;
 
-            $this->output_text = '';
+            $this->outputText = '';
             $this->content = null;
             $this->error = null;
 
@@ -44,7 +44,7 @@ class AnthropicResponse extends Model
                 $this->content = $responseData['content'];
                 foreach ($responseData['content'] as $contentBlock) {
                     if (isset($contentBlock['type']) && $contentBlock['type'] === 'text') {
-                        $this->output_text = trim($contentBlock['text']);
+                        $this->outputText = trim($contentBlock['text']);
                         break;
                     }
                 }
@@ -87,7 +87,7 @@ class AnthropicResponse extends Model
     public function defineRules(): array
     {
         return [
-            ['output_text', 'string'],
+            ['outputText', 'string'],
             ['content', 'safe'],
             ['error', 'safe'],
         ];
@@ -114,7 +114,7 @@ class AnthropicResponse extends Model
      */
     public function getText(): string
     {
-        return $this->output_text;
+        return $this->outputText;
     }
 
     /**

--- a/src/models/api/AnthropicResponse.php
+++ b/src/models/api/AnthropicResponse.php
@@ -2,10 +2,10 @@
 
 namespace heavymetalavo\craftaialttext\models\api;
 
+use Craft;
 use craft\base\Model;
 use craft\helpers\Json;
 use Exception;
-use Craft;
 
 /**
  * Anthropic Response Model

--- a/src/models/api/OpenAiRequest.php
+++ b/src/models/api/OpenAiRequest.php
@@ -7,127 +7,53 @@ use craft\base\Model;
 /**
  * OpenAI Request Model
  *
- * Represents a request to the OpenAI API for vision analysis.
- * This model handles the structure and validation of API requests, including the model to use and input to send.
- *
- * @property string $model The OpenAI model to use (e.g., 'gpt-4o-mini')
- * @property array $input The input array containing the role and content
- * @property-read string $detail The detail level for image analysis
+ * Represents a request to the OpenAI Responses API for vision analysis.
  */
 class OpenAiRequest extends Model
 {
     public string $model = '';
-    public array $input = [];
 
     private string $prompt = '';
     private string $imageUrl = '';
     private string $detail = 'low';
 
-    /**
-     * Gets the detail level for image analysis
-     *
-     * @return string The detail level
-     */
     public function getDetail(): string
     {
         return $this->detail;
     }
 
-    /**
-     * Sets the prompt text for the request
-     *
-     * @param string $prompt The prompt text to use
-     * @return self For method chaining
-     */
     public function setPrompt(string $prompt): self
     {
         $this->prompt = $prompt;
-        $this->buildInput();
         return $this;
     }
 
-    /**
-     * Sets the image URL for the request
-     *
-     * @param string $imageUrl The URL of the image to analyze
-     * @return self For method chaining
-     */
     public function setImageUrl(string $imageUrl): self
     {
         $this->imageUrl = $imageUrl;
-        $this->buildInput();
         return $this;
     }
 
-    /**
-     * Sets the detail level for image analysis
-     *
-     * @param string $detail The detail level (auto, low, or high)
-     * @return self For method chaining
-     */
     public function setDetail(string $detail): self
     {
         $this->detail = $detail;
-        $this->buildInput();
         return $this;
     }
 
     /**
-     * Builds the input array structure from the current properties
-     */
-    private function buildInput(): void
-    {
-        $content = [];
-
-        // Add text content if prompt is set
-        if (!empty($this->prompt)) {
-            $content[] = [
-                'type' => 'input_text',
-                'text' => $this->prompt
-            ];
-        }
-
-        // Add image content if imageUrl is set
-        if (!empty($this->imageUrl)) {
-            $content[] = [
-                'type' => 'input_image',
-                'image_url' => $this->imageUrl,
-                'detail' => $this->detail
-            ];
-        }
-
-        // Set the input array with the built content
-        $this->input = [
-            [
-                'role' => 'user',
-                'content' => $content
-            ]
-        ];
-    }
-
-    /**
-     * Defines the validation rules for the request model.
-     *
-     * @return array The validation rules
+     * @inheritdoc
      */
     public function defineRules(): array
     {
         return [
-            [['model', 'input'], 'required'],
+            ['model', 'required'],
             ['model', 'string'],
-            ['input', 'safe'],
             ['model', 'validateDetail'],
         ];
     }
 
-    /**
-     * Validates the detail property
-     *
-     * @return void
-     */
     public function validateDetail(): void
     {
-        // Custom validator for detail value
         if (!in_array($this->detail, ['auto', 'low', 'high'])) {
             $this->addError('detail', 'Detail must be one of: auto, low, high');
         }
@@ -136,25 +62,33 @@ class OpenAiRequest extends Model
     /**
      * @inheritdoc
      */
-    public function fields(): array
-    {
-        $fields = parent::fields();
-        // Add virtual fields
-        $fields['detail'] = function(self $model) {
-            return $model->getDetail();
-        };
-        return $fields;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function toArray(array $fields = [], array $expand = [], $recursive = true): array
     {
-        // Override the parent toArray to ensure our specific structure
+        $content = [];
+
+        if (!empty($this->prompt)) {
+            $content[] = [
+                'type' => 'input_text',
+                'text' => $this->prompt,
+            ];
+        }
+
+        if (!empty($this->imageUrl)) {
+            $content[] = [
+                'type' => 'input_image',
+                'image_url' => $this->imageUrl,
+                'detail' => $this->detail,
+            ];
+        }
+
         return [
             'model' => $this->model,
-            'input' => $this->input,
+            'input' => [
+                [
+                    'role' => 'user',
+                    'content' => $content,
+                ],
+            ],
         ];
     }
 }

--- a/src/models/api/OpenAiRequest.php
+++ b/src/models/api/OpenAiRequest.php
@@ -54,8 +54,8 @@ class OpenAiRequest extends Model
 
     public function validateDetail(): void
     {
-        if (!in_array($this->detail, ['auto', 'low', 'high'])) {
-            $this->addError('detail', 'Detail must be one of: auto, low, high');
+        if (!in_array($this->detail, ['low', 'high', 'original', 'auto'])) {
+            $this->addError('detail', 'Detail must be one of: low, high, original, auto');
         }
     }
 

--- a/src/models/api/OpenAiResponse.php
+++ b/src/models/api/OpenAiResponse.php
@@ -2,10 +2,10 @@
 
 namespace heavymetalavo\craftaialttext\models\api;
 
+use Craft;
 use craft\base\Model;
 use craft\helpers\Json;
 use Exception;
-use Craft;
 
 /**
  * OpenAI Response Model

--- a/src/models/api/OpenAiResponse.php
+++ b/src/models/api/OpenAiResponse.php
@@ -13,15 +13,11 @@ use Craft;
  * Represents a response from the OpenAI API.
  * This model handles the structure and validation of API responses, including the generated content and any errors.
  *
- * @property string $output_text The generated content from the API
- * @property array|null $output The full output structure from the API
- * @property array|null $content The content array from the API
- * @property array|null $error Error information if the request failed
- * @property array|null $rawData The raw response data from the API
+ * Represents a response from the OpenAI API.
  */
 class OpenAiResponse extends Model
 {
-    public string $output_text = '';
+    public string $outputText = '';
     public ?array $output = null;
     public ?array $content = null;
     public ?array $error = null;
@@ -39,55 +35,43 @@ class OpenAiResponse extends Model
             $responseData = Json::decode($responseBody);
             $this->rawData = $responseData;
 
-            // Reset properties
-            $this->output_text = '';
+            $this->outputText = '';
             $this->output = null;
             $this->content = null;
             $this->error = null;
 
-            // Check for error messages first
             if (isset($responseData['error'])) {
+                $errorDetails = is_array($responseData['error']) ? $responseData['error'] : null;
                 $errorMessage = is_array($responseData['error'])
                     ? ($responseData['error']['message'] ?? Json::encode($responseData['error']))
                     : $responseData['error'];
-                $this->setError($errorMessage, $responseData['error']);
+                $this->setError($errorMessage, $errorDetails);
                 return false;
             }
 
-            // Store the output if it exists
             if (isset($responseData['output']) && is_array($responseData['output'])) {
                 $this->output = $responseData['output'];
 
-                // Look for the message in the output array
                 foreach ($responseData['output'] as $outputItem) {
                     if (isset($outputItem['content']) && is_array($outputItem['content'])) {
                         $this->content = $outputItem['content'];
 
-                        // Look for the text content
                         foreach ($outputItem['content'] as $contentItem) {
                             if (isset($contentItem['type']) && $contentItem['type'] === 'output_text' && isset($contentItem['text'])) {
-                                $this->output_text = $contentItem['text'];
-                                break 2; // Break out of both loops
+                                $this->outputText = $contentItem['text'];
+                                break 2;
                             }
                         }
                     }
                 }
-            }
-            // Check if output_text exists directly
-            elseif (isset($responseData['output_text'])) {
-                $this->output_text = $responseData['output_text'];
-            }
-            // Check for ChatGPT completion style responses
-            elseif (isset($responseData['choices']) && is_array($responseData['choices'])) {
-                if (isset($responseData['choices'][0]['message']['content'])) {
-                    $this->output_text = $responseData['choices'][0]['message']['content'];
-                    $this->content = [
-                        ['type' => 'output_text', 'text' => $this->output_text]
-                    ];
-                }
-            }
-            // If we can't find any output, log the entire response
-            else {
+            } elseif (isset($responseData['output_text'])) {
+                $this->outputText = $responseData['output_text'];
+            } elseif (isset($responseData['choices'][0]['message']['content'])) {
+                $this->outputText = $responseData['choices'][0]['message']['content'];
+                $this->content = [
+                    ['type' => 'output_text', 'text' => $this->outputText],
+                ];
+            } else {
                 Craft::warning('Could not find output_text in response: ' . Json::encode($responseData), __METHOD__);
                 $this->setError('Could not parse response from OpenAI API.');
                 return false;
@@ -133,7 +117,7 @@ class OpenAiResponse extends Model
     public function defineRules(): array
     {
         return [
-            ['output_text', 'string'],
+            ['outputText', 'string'],
             ['output', 'safe'],
             ['content', 'safe'],
             ['error', 'safe'],
@@ -167,7 +151,7 @@ class OpenAiResponse extends Model
      */
     public function getText(): string
     {
-        return $this->output_text;
+        return $this->outputText;
     }
 
     /**

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -3,12 +3,12 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
-use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
 use craft\enums\MenuItemType;
 use craft\events\DefineMenuItemsEvent;
 use craft\helpers\App;
+use Exception;
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
 

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -3,41 +3,23 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
+use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
+use craft\enums\MenuItemType;
+use craft\events\DefineMenuItemsEvent;
+use craft\helpers\App;
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
-use Exception;
-use craft\events\DefineMenuItemsEvent;
-use craft\enums\MenuItemType;
-use craft\helpers\App;
 
 /**
  * AI Alt Text Service
  *
  * Main service class for generating alt text using AI.
- * This service coordinates between the OpenAI service and Craft CMS assets.
- *
- * @property OpenAiService $openAiService The OpenAI service instance
+ * This service coordinates between the provider services and Craft CMS assets.
  */
 class AiAltTextService extends Component
 {
-    private OpenAiService $openAiService;
-    private AnthropicService $anthropicService;
-
-
-    /**
-     * Constructor
-     *
-     * Initializes the service with the OpenAI service instance.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-        $this->openAiService = new OpenAiService();
-
-        $this->anthropicService = new AnthropicService();
-    }
 
     /**
      * Creates a job for the given element
@@ -167,20 +149,21 @@ class AiAltTextService extends Component
         if ($asset->kind !== Asset::KIND_IMAGE) {
             throw new Exception('Asset must be an image');
         }
-
-        $provider = App::parseEnv(AiAltText::getInstance()->getSettings()->aiProvider);
+        
+        $plugin = AiAltText::getInstance();
+        $provider = App::parseEnv($plugin->getSettings()->aiProvider);
 
         if ($provider === 'anthropic') {
-            $altText = $this->anthropicService->generateAltText($asset, $siteId);
+            $altText = $plugin->anthropicService->generateAltText($asset, $siteId);
         } else {
-            $altText = $this->openAiService->generateAltText($asset, $siteId);
+            $altText = $plugin->openAiService->generateAltText($asset, $siteId);
         }
 
         if (empty($altText)) {
             throw new Exception('Empty alt text generated for asset: ' . $asset->filename);
         }
 
-        $propagate = (bool) AiAltText::getInstance()->getSettings()->propagate;
+        $propagate = (bool) $plugin->getSettings()->propagate;
 
         // Bug Workaround: Pre-save blank alt text to prevent propagation across sites where setting is false.
         if (!$propagate) {

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -167,7 +167,7 @@ class AiAltTextService extends Component
             throw new Exception('Asset must be an image');
         }
 
-        $provider = AiAltText::getInstance()->getSettings()->aiProvider;
+        $provider = \craft\helpers\App::parseEnv(AiAltText::getInstance()->getSettings()->aiProvider);
 
         if ($provider === 'anthropic') {
             $altText = $this->anthropicService->generateAltText($asset, $siteId);

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -10,6 +10,7 @@ use heavymetalavo\craftaialttext\jobs\GenerateAiAltText as GenerateAiAltTextJob;
 use Exception;
 use craft\events\DefineMenuItemsEvent;
 use craft\enums\MenuItemType;
+use craft\helpers\App;
 
 /**
  * AI Alt Text Service
@@ -167,7 +168,7 @@ class AiAltTextService extends Component
             throw new Exception('Asset must be an image');
         }
 
-        $provider = \craft\helpers\App::parseEnv(AiAltText::getInstance()->getSettings()->aiProvider);
+        $provider = App::parseEnv(AiAltText::getInstance()->getSettings()->aiProvider);
 
         if ($provider === 'anthropic') {
             $altText = $this->anthropicService->generateAltText($asset, $siteId);

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -22,6 +22,8 @@ use craft\enums\MenuItemType;
 class AiAltTextService extends Component
 {
     private OpenAiService $openAiService;
+    private AnthropicService $anthropicService;
+
 
     /**
      * Constructor
@@ -32,6 +34,8 @@ class AiAltTextService extends Component
     {
         parent::__construct();
         $this->openAiService = new OpenAiService();
+
+        $this->anthropicService = new AnthropicService();
     }
 
     /**
@@ -157,13 +161,19 @@ class AiAltTextService extends Component
      * @return string The generated alt text
      * @throws Exception If the asset is invalid or alt text generation fails
      */
-    public function generateAltText(Asset $asset, int $siteId = null, bool $forceRegeneration = false): string
+    public function generateAltText(Asset $asset, ?int $siteId = null, bool $forceRegeneration = false): string
     {
         if ($asset->kind !== Asset::KIND_IMAGE) {
             throw new Exception('Asset must be an image');
         }
 
-        $altText = $this->openAiService->generateAltText($asset, $siteId);
+        $provider = AiAltText::getInstance()->getSettings()->aiProvider;
+
+        if ($provider === 'anthropic') {
+            $altText = $this->anthropicService->generateAltText($asset, $siteId);
+        } else {
+            $altText = $this->openAiService->generateAltText($asset, $siteId);
+        }
 
         if (empty($altText)) {
             throw new Exception('Empty alt text generated for asset: ' . $asset->filename);

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -180,8 +180,19 @@ class AiAltTextService extends Component
             throw new Exception('Empty alt text generated for asset: ' . $asset->filename);
         }
 
+        $propagate = (bool) AiAltText::getInstance()->getSettings()->propagate;
+
+        // Bug Workaround: Pre-save blank alt text to prevent propagation across sites where setting is false.
+        if (!$propagate) {
+            $asset->alt = '';
+            Craft::debug("Performing preliminary save for asset {$asset->id} to establish site rows before setting alt text.", __METHOD__);
+            Craft::$app->elements->saveElement($asset, true, false);
+        }
+
         $asset->alt = $altText;
-        $propagate = AiAltText::getInstance()->getSettings()->propagate;
+        
+        Craft::debug("Saving AI alt text for asset {$asset->id} with propagate=" . ($propagate ? 'true' : 'false'), __METHOD__);
+        
         if (!Craft::$app->elements->saveElement($asset, true, $propagate)) {
             throw new Exception('Failed to save alt text for asset: ' . $asset->filename);
         }

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -15,7 +15,7 @@ use heavymetalavo\craftaialttext\models\api\AnthropicResponse;
 /**
  * Anthropic API Service
  *
- * Handles API interactions with Anthropic's Claude to generate alt text via the Messages API.
+ * Handles API interactions with the Anthropic Messages API to generate alt text.
  */
 class AnthropicService extends ApiService
 {
@@ -27,15 +27,15 @@ class AnthropicService extends ApiService
     public function __construct()
     {
         parent::__construct();
-        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->claudeApiKey);
-        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->claudeModel);
-        $this->detailLevel = AiAltText::getInstance()->getSettings()->claudeImageDetailLevel;
+        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicApiKey);
+        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicModel);
+        $this->detailLevel = AiAltText::getInstance()->getSettings()->anthropicImageDetailLevel;
     }
 
 
 
     /**
-     * Generates alt text using Claude Messages API
+     * Generates alt text using the Anthropic Messages API
      */
     public function generateAltText(Asset $asset, ?int $siteId = null): string
     {
@@ -49,7 +49,7 @@ class AnthropicService extends ApiService
             default => 1000,
         };
 
-        // Claude Vision: max long edge based on detail level, max 5MB payload, max ~1600 tokens
+        // Anthropic Vision: max long edge based on detail level, max 5MB payload, max ~1600 tokens
         $transformParams = $this->getVisionTransformParams($asset, maxLongEdge: $targetDimension, maxFileSizeMb: 5, maxTokens: 1600);
         
         if (!empty($transformParams)) {

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -3,14 +3,12 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
+use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
-use craft\helpers\App;
-use craft\helpers\Json;
-use Exception;
+use craft\helpers\{App, Json};
 use heavymetalavo\craftaialttext\AiAltText;
-use heavymetalavo\craftaialttext\models\api\AnthropicRequest;
-use heavymetalavo\craftaialttext\models\api\AnthropicResponse;
+use heavymetalavo\craftaialttext\models\api\{AnthropicRequest, AnthropicResponse};
 
 /**
  * Anthropic API Service
@@ -27,9 +25,10 @@ class AnthropicService extends ApiService
     public function __construct()
     {
         parent::__construct();
-        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicApiKey);
-        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicModel);
-        $this->detailLevel = AiAltText::getInstance()->getSettings()->anthropicImageDetailLevel;
+        $plugin = AiAltText::getInstance();
+        $this->apiKey = App::parseEnv($plugin->getSettings()->anthropicApiKey);
+        $this->model = App::parseEnv($plugin->getSettings()->anthropicModel);
+        $this->detailLevel = $plugin->getSettings()->anthropicImageDetailLevel;
     }
 
 

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\services;
+
+use Craft;
+use craft\base\Component;
+use craft\elements\Asset;
+use craft\helpers\App;
+use Exception;
+use heavymetalavo\craftaialttext\AiAltText;
+use heavymetalavo\craftaialttext\models\api\AnthropicRequest;
+use heavymetalavo\craftaialttext\models\api\AnthropicResponse;
+
+/**
+ * Anthropic API Service
+ *
+ * Handles API interactions with Anthropic's Claude to generate alt text via the Messages API.
+ */
+class AnthropicService extends Component
+{
+    private string $apiKey;
+    private string $model;
+    private string $detailLevel;
+    private string $baseUrl = 'https://api.anthropic.com/v1/messages';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicApiKey);
+        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicModel);
+        $this->detailLevel = AiAltText::getInstance()->getSettings()->anthropicImageDetailLevel;
+    }
+
+    /**
+     * Checks if a URL is accessible remotely
+     */
+    private function isUrlAccessible(string $url): bool
+    {
+        try {
+            $client = Craft::createGuzzleClient();
+            $response = $client->head($url, [
+                'timeout' => 5,
+                'connect_timeout' => 5,
+                'allow_redirects' => true,
+            ]);
+            return $response->getStatusCode() === 200;
+        } catch (Exception $e) {
+            Craft::warning('URL accessibility check failed: ' . $e->getMessage(), __METHOD__);
+            return false;
+        }
+    }
+
+    /**
+     * Generates alt text using Claude Messages API
+     */
+    public function generateAltText(Asset $asset, ?int $siteId = null): string
+    {
+        $mimeType = strtolower($asset->getMimeType());
+        $acceptedMimeTypes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+        
+        $needsFormatConversion = !in_array($mimeType, $acceptedMimeTypes);
+        if ($mimeType === 'image/gif') {
+            $fileContents = $asset->getContents();
+            if (substr_count($fileContents, "\x21\xF9\x04") > 1) {
+                $needsFormatConversion = true; // Attempt to grab single frame by converting
+            }
+        }
+
+        if (!Craft::$app->getConfig()->getGeneral()->transformSvgs && $mimeType === 'image/svg+xml') {
+            throw new Exception('SVGs are not supported by the Anthropic API and transformSvgs is disabled.');
+        }
+        
+        $transformParams = [
+            'mode'  => 'fit',
+        ];
+        if ($needsFormatConversion) {
+            $transformParams['format'] = $mimeType === 'image/svg+xml' ? 'png' : 'jpg';
+        }
+
+        $targetDimension = match ($this->detailLevel) {
+            'very_low' => 200,
+            'low' => 500,
+            'high' => 1536,
+            default => 1000, // medium
+        };
+
+        // Avoid extremely large images for API
+        $width = $asset->getWidth();
+        $height = $asset->getHeight();
+        
+        if ($width > $targetDimension || $height > $targetDimension) {
+            if ($width >= $height) {
+                // Wide image
+                $transformParams['width'] = $targetDimension;
+                // keep aspect ratio by adjusting height relative to the original aspect ratio
+                $transformParams['height'] = (int)round(($height / $width) * $targetDimension); 
+            } else {
+                // Tall image
+                $transformParams['height'] = $targetDimension;
+                $transformParams['width'] = (int)round(($width / $height) * $targetDimension);
+            }
+        }
+
+        if (empty($transformParams) && $asset->size > 20 * 1024 * 1024) {
+            $transformParams['quality'] = 75;
+        }
+
+        $asset->setTransform($transformParams);
+        $transformMimeType = $asset->getMimeType($transformParams);
+        $imageUrl = $asset->getUrl($transformParams, true);
+
+        if (!empty($imageUrl) && !$this->isUrlAccessible($imageUrl)) {
+            $imageUrl = null;
+        }
+
+        $imageSource = null;
+        
+        // Always try to fetch the transformed URL using Guzzle to get the resized contents
+        if (!empty($imageUrl)) {
+            try {
+                $client = Craft::createGuzzleClient();
+                $response = $client->get($imageUrl, ['timeout' => 10]);
+                if ($response->getStatusCode() === 200) {
+                    $assetContents = (string)$response->getBody();
+                    $base64Image = base64_encode($assetContents);
+                    $imageSource = [
+                        'type' => 'base64',
+                        'media_type' => $transformMimeType,
+                        'data' => $base64Image,
+                    ];
+                }
+            } catch (Exception $e) {
+                Craft::warning('Failed to download transformed image URL for Anthropic: ' . $e->getMessage(), __METHOD__);
+                $imageUrl = null; // Trigger fallback
+            }
+        }
+
+        // Fallback to original asset contents if URL wasn't accessible or downloaded
+        if (empty($imageSource)) {
+            $assetContents = $asset->getContents();
+            $base64Image = base64_encode($assetContents);
+            $imageSource = [
+                'type' => 'base64',
+                'media_type' => $transformMimeType,
+                'data' => $base64Image,
+            ];
+            Craft::warning("Anthropic API: No URL available or download failed for transformed image $asset->filename. Using original, un-scaled asset file contents for base64 encoding.", __METHOD__);
+        }
+
+        return $this->sendAnthropicRequest(null, $imageSource, $transformMimeType, $asset, $siteId);
+    }
+
+    private function sendAnthropicRequest(?string $imageUrl, ?array $imageSource, string $mimeType, Asset $asset, ?int $siteId): string
+    {
+        $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
+
+        $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
+            return $asset->{$matches[1]};
+        }, $promptTemplate);
+
+        $site = Craft::$app->getSites()->getSiteById($siteId);
+        $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
+            return $site->{$matches[1]};
+        }, $prompt);
+
+        if (empty($prompt)) {
+            $prompt = 'Describe this image for an alt text.';
+        }
+
+        $requestModel = new AnthropicRequest();
+        $requestModel->model = $this->model;
+        $requestModel->setPrompt($prompt);
+        if ($imageSource) {
+            $requestModel->setImageSource($imageSource);
+        } elseif ($imageUrl) {
+            $requestModel->setImageUrl($imageUrl);
+        }
+
+        if (!$requestModel->validate()) {
+            throw new Exception("Invalid Anthropic request: " . \json_encode($requestModel->getErrors()));
+        }
+
+        $client = Craft::createGuzzleClient();
+
+        try {
+            $response = $client->post($this->baseUrl, [
+                'headers' => [
+                    'x-api-key' => $this->apiKey,
+                    'anthropic-version' => '2023-06-01',
+                    'content-type' => 'application/json',
+                ],
+                'json' => $requestModel->toArray(),
+            ]);
+
+            $responseBody = (string)$response->getBody();
+            
+            $responseModel = new AnthropicResponse();
+            if (!$responseModel->parseResponse($responseBody)) {
+                throw new Exception("Anthropic API returned error: " . $responseModel->getErrorMessage());
+            }
+
+            return $responseModel->getText();
+        } catch (\GuzzleHttp\Exception\RequestException $e) {
+            $errorResponse = $e->hasResponse() ? (string)$e->getResponse()->getBody() : $e->getMessage();
+            Craft::error("Anthropic API Error: " . $errorResponse, __METHOD__);
+            
+            $responseModel = new AnthropicResponse();
+            if ($responseModel->parseResponse($errorResponse) && $responseModel->hasError()) {
+                throw new Exception("Anthropic API request failed: " . $responseModel->getErrorMessage());
+            }
+            throw new Exception("Anthropic API request failed: " . $errorResponse);
+        }
+    }
+}

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -82,10 +82,10 @@ class AnthropicService extends ApiService
                 'media_type' => $transformMimeType,
                 'data' => $base64Image,
             ];
-            return $this->sendRequest(null, $imageSource, $transformMimeType, $asset, $siteId);
+            $imageUrl = null;
         }
 
-        return $this->sendRequest($imageUrl, null, $transformMimeType, $asset, $siteId);
+        return $this->sendRequest($imageUrl, $imageSource, $transformMimeType, $asset, $siteId);
     }
 
     private function sendRequest(?string $imageUrl, ?array $base64ImageSource, string $mimeType, Asset $asset, ?int $siteId): string

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -31,8 +31,6 @@ class AnthropicService extends ApiService
         $this->detailLevel = $plugin->getSettings()->anthropicImageDetailLevel;
     }
 
-
-
     /**
      * Generates alt text using the Anthropic Messages API
      */

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -26,9 +26,9 @@ class AnthropicService extends ApiService
     public function __construct()
     {
         parent::__construct();
-        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicApiKey);
-        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->anthropicModel);
-        $this->detailLevel = AiAltText::getInstance()->getSettings()->anthropicImageDetailLevel;
+        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->claudeApiKey);
+        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->claudeModel);
+        $this->detailLevel = AiAltText::getInstance()->getSettings()->claudeImageDetailLevel;
     }
 
 

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -3,10 +3,10 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
-use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
 use craft\helpers\{App, Json};
+use Exception;
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\models\api\{AnthropicRequest, AnthropicResponse};
 
@@ -39,7 +39,7 @@ class AnthropicService extends ApiService
         $this->validateImageSupport($asset);
 
         $targetDimension = match ($this->detailLevel) {
-            'very_low' => 300,
+            'veryLow' => 300,
             'low' => 500,
             'medium' => 1000,
             'high' => 1568,

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -39,7 +39,6 @@ class AnthropicService extends ApiService
         $this->validateImageSupport($asset);
 
         $targetDimension = match ($this->detailLevel) {
-            'veryLow' => 300,
             'low' => 500,
             'medium' => 1000,
             'high' => 1568,

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
 use craft\helpers\App;
+use craft\helpers\Json;
 use Exception;
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\models\api\AnthropicRequest;
@@ -115,7 +116,7 @@ class AnthropicService extends ApiService
             }
 
             if (!$requestModel->validate()) {
-                throw new Exception("Invalid Anthropic request: " . \json_encode($requestModel->getErrors()));
+                throw new Exception("Invalid Anthropic request: " . Json::encode($requestModel->getErrors()));
             }
 
             // Convert explicit request structure to array for the JSON payload

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -16,7 +16,7 @@ use heavymetalavo\craftaialttext\models\api\AnthropicResponse;
  *
  * Handles API interactions with Anthropic's Claude to generate alt text via the Messages API.
  */
-class AnthropicService extends Component
+class AnthropicService extends ApiService
 {
     private string $apiKey;
     private string $model;
@@ -31,165 +31,103 @@ class AnthropicService extends Component
         $this->detailLevel = AiAltText::getInstance()->getSettings()->anthropicImageDetailLevel;
     }
 
-    /**
-     * Checks if a URL is accessible remotely
-     */
-    private function isUrlAccessible(string $url): bool
-    {
-        try {
-            $client = Craft::createGuzzleClient();
-            $response = $client->head($url, [
-                'timeout' => 5,
-                'connect_timeout' => 5,
-                'allow_redirects' => true,
-            ]);
-            return $response->getStatusCode() === 200;
-        } catch (Exception $e) {
-            Craft::warning('URL accessibility check failed: ' . $e->getMessage(), __METHOD__);
-            return false;
-        }
-    }
+
 
     /**
      * Generates alt text using Claude Messages API
      */
     public function generateAltText(Asset $asset, ?int $siteId = null): string
     {
-        $mimeType = strtolower($asset->getMimeType());
-        $acceptedMimeTypes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
-        
-        $needsFormatConversion = !in_array($mimeType, $acceptedMimeTypes);
-        if ($mimeType === 'image/gif') {
-            $fileContents = $asset->getContents();
-            if (substr_count($fileContents, "\x21\xF9\x04") > 1) {
-                $needsFormatConversion = true; // Attempt to grab single frame by converting
-            }
-        }
-
-        if (!Craft::$app->getConfig()->getGeneral()->transformSvgs && $mimeType === 'image/svg+xml') {
-            throw new Exception('SVGs are not supported by the Anthropic API and transformSvgs is disabled.');
-        }
-        
-        $transformParams = [
-            'mode'  => 'fit',
-        ];
-        if ($needsFormatConversion) {
-            $transformParams['format'] = $mimeType === 'image/svg+xml' ? 'png' : 'jpg';
-        }
+        $this->validateImageSupport($asset);
 
         $targetDimension = match ($this->detailLevel) {
-            'very_low' => 200,
+            'very_low' => 300,
             'low' => 500,
-            'high' => 1536,
-            default => 1000, // medium
+            'medium' => 1000,
+            'high' => 1568,
+            default => 1000,
         };
 
-        // Avoid extremely large images for API
-        $width = $asset->getWidth();
-        $height = $asset->getHeight();
+        // Claude Vision: max long edge based on detail level, max 5MB payload, max ~1600 tokens
+        $transformParams = $this->getVisionTransformParams($asset, maxLongEdge: $targetDimension, maxFileSizeMb: 5, maxTokens: 1600);
         
-        if ($width > $targetDimension || $height > $targetDimension) {
-            if ($width >= $height) {
-                // Wide image
-                $transformParams['width'] = $targetDimension;
-                // keep aspect ratio by adjusting height relative to the original aspect ratio
-                $transformParams['height'] = (int)round(($height / $width) * $targetDimension); 
-            } else {
-                // Tall image
-                $transformParams['height'] = $targetDimension;
-                $transformParams['width'] = (int)round(($width / $height) * $targetDimension);
-            }
+        if (!empty($transformParams)) {
+            $asset->setTransform($transformParams);
         }
 
-        if (empty($transformParams) && $asset->size > 20 * 1024 * 1024) {
-            $transformParams['quality'] = 75;
-        }
-
-        $asset->setTransform($transformParams);
+        // Output mime-type
         $transformMimeType = $asset->getMimeType($transformParams);
+        
+        if (!$this->isAcceptedMimeType($transformMimeType)) {
+            throw new Exception("Asset transform produced unsupported MIME type: $transformMimeType. Supported formats are: " . implode(', ', self::ACCEPTED_MIME_TYPES));
+        }
+        
         $imageUrl = $asset->getUrl($transformParams, true);
 
-        if (!empty($imageUrl) && !$this->isUrlAccessible($imageUrl)) {
-            $imageUrl = null;
+        // If we have a URL, check if it's accessible remotely
+        if (!empty($imageUrl)) {
+            if (!$this->isUrlAccessible($imageUrl)) {
+                Craft::warning('Asset URL is not accessible remotely: ' . $imageUrl, __METHOD__);
+                $imageUrl = null; // Reset to null to trigger base64 encoding
+            }
         }
 
         $imageSource = null;
-        
-        // Always try to fetch the transformed URL using Guzzle to get the resized contents
-        if (!empty($imageUrl)) {
-            try {
-                $client = Craft::createGuzzleClient();
-                $response = $client->get($imageUrl, ['timeout' => 10]);
-                if ($response->getStatusCode() === 200) {
-                    $assetContents = (string)$response->getBody();
-                    $base64Image = base64_encode($assetContents);
-                    $imageSource = [
-                        'type' => 'base64',
-                        'media_type' => $transformMimeType,
-                        'data' => $base64Image,
-                    ];
-                }
-            } catch (Exception $e) {
-                Craft::warning('Failed to download transformed image URL for Anthropic: ' . $e->getMessage(), __METHOD__);
-                $imageUrl = null; // Trigger fallback
-            }
-        }
 
-        // Fallback to original asset contents if URL wasn't accessible or downloaded
-        if (empty($imageSource)) {
-            $assetContents = $asset->getContents();
-            $base64Image = base64_encode($assetContents);
+        // If no public URL is available or URL is not accessible, fall back to base64 encoding
+        if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
+            $base64Image = $this->getAssetBase64String($asset, $imageUrl, $transformParams);
             $imageSource = [
                 'type' => 'base64',
                 'media_type' => $transformMimeType,
                 'data' => $base64Image,
             ];
-            Craft::warning("Anthropic API: No URL available or download failed for transformed image $asset->filename. Using original, un-scaled asset file contents for base64 encoding.", __METHOD__);
+            return $this->sendRequest(null, $imageSource, $transformMimeType, $asset, $siteId);
         }
 
-        return $this->sendAnthropicRequest(null, $imageSource, $transformMimeType, $asset, $siteId);
+        return $this->sendRequest($imageUrl, null, $transformMimeType, $asset, $siteId);
     }
 
-    private function sendAnthropicRequest(?string $imageUrl, ?array $imageSource, string $mimeType, Asset $asset, ?int $siteId): string
+    private function sendRequest(?string $imageUrl, ?array $base64ImageSource, string $mimeType, Asset $asset, ?int $siteId): string
     {
-        $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
-
-        $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
-            return $asset->{$matches[1]};
-        }, $promptTemplate);
-
-        $site = Craft::$app->getSites()->getSiteById($siteId);
-        $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
-            return $site->{$matches[1]};
-        }, $prompt);
-
-        if (empty($prompt)) {
-            $prompt = 'Describe this image for an alt text.';
-        }
-
-        $requestModel = new AnthropicRequest();
-        $requestModel->model = $this->model;
-        $requestModel->setPrompt($prompt);
-        if ($imageSource) {
-            $requestModel->setImageSource($imageSource);
-        } elseif ($imageUrl) {
-            $requestModel->setImageUrl($imageUrl);
-        }
-
-        if (!$requestModel->validate()) {
-            throw new Exception("Invalid Anthropic request: " . \json_encode($requestModel->getErrors()));
-        }
-
-        $client = Craft::createGuzzleClient();
-
         try {
-            $response = $client->post($this->baseUrl, [
+            // Log the request intent for debugging
+            Craft::info('Anthropic API request initiated for asset: ' . $asset->filename, __METHOD__);
+
+            $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
+
+            $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
+                return $asset->{$matches[1]};
+            }, $promptTemplate);
+
+            $site = Craft::$app->getSites()->getSiteById($siteId);
+            $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
+                return $site->{$matches[1]};
+            }, $prompt);
+
+            $requestModel = new AnthropicRequest();
+            $requestModel->model = $this->model;
+            $requestModel->setPrompt($prompt);
+            if ($base64ImageSource) {
+                $requestModel->setImageSource($base64ImageSource);
+            } elseif ($imageUrl) {
+                $requestModel->setImageUrl($imageUrl);
+            }
+
+            if (!$requestModel->validate()) {
+                throw new Exception("Invalid Anthropic request: " . \json_encode($requestModel->getErrors()));
+            }
+
+            // Convert explicit request structure to array for the JSON payload
+            $requestArray = $requestModel->toArray();
+
+            $response = $this->client->post($this->baseUrl, [
                 'headers' => [
                     'x-api-key' => $this->apiKey,
                     'anthropic-version' => '2023-06-01',
                     'content-type' => 'application/json',
                 ],
-                'json' => $requestModel->toArray(),
+                'json' => $requestArray,
             ]);
 
             $responseBody = (string)$response->getBody();

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\services;
+
+use Craft;
+use craft\base\Component;
+use craft\elements\Asset;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * Base API Service
+ *
+ * Provides shared logic for image preparation, transformation, and downloading
+ * via Guzzle before sending payloads to specific AI Provider services.
+ */
+abstract class ApiService extends Component
+{
+    /**
+     * @var array Standard supported image formats across most AI Vision providers
+     */
+    public const ACCEPTED_MIME_TYPES = [
+        'image/png',
+        'image/jpeg',
+        'image/webp',
+        'image/gif'
+    ];
+
+    /**
+     * @var Client
+     */
+    protected Client $client;
+
+    public function __construct($config = [])
+    {
+        parent::__construct($config);
+        $this->client = Craft::createGuzzleClient(['timeout' => 10]);
+    }
+    /**
+     * Required implementation for child services to generate their specific payloads.
+     */
+    abstract public function generateAltText(Asset $asset, ?int $siteId = null): string;
+
+    /**
+     * Checks if a URL is accessible remotely.
+     *
+     * @param string $url The URL to check
+     * @return bool Whether the URL is accessible
+     */
+    protected function isUrlAccessible(string $url): bool
+    {
+        try {
+            $response = $this->client->head($url, [
+                'timeout' => 5,
+                'connect_timeout' => 5,
+                'allow_redirects' => true,
+            ]);
+            return $response->getStatusCode() === 200;
+        } catch (Exception $e) {
+            Craft::warning('URL accessibility check failed: ' . $e->getMessage(), __METHOD__);
+            return false;
+        }
+    }
+
+    /**
+     * Validates if the asset is an accepted image format natively.
+     *
+     * @param Asset $asset The asset to validate
+     * @param bool $allowSvgs Whether the endpoint natively supports SVGs or relies on Craft's SVG transform pipeline
+     * @throws Exception If the asset format is invalid or fundamentally unsupported
+     */
+    protected function validateImageSupport(Asset $asset, bool $allowSvgs = false): void
+    {
+        $mimeType = strtolower($asset->getMimeType());
+
+        if ($mimeType === 'image/svg+xml') {
+            if (!$allowSvgs && !Craft::$app->getConfig()->getGeneral()->transformSvgs) {
+                throw new Exception("SVGs are not natively supported by this API provider and Craft's `transformSvgs` explicitly disables fallback rasterization.");
+            }
+        }
+    }
+
+    /**
+     * Checks if a GIF asset contains multiple frames (animated).
+     *
+     * @param Asset $asset The asset to check
+     * @return bool Whether the GIF is animated
+     */
+    protected function isAnimatedGif(Asset $asset): bool
+    {
+        $mimeType = strtolower($asset->getMimeType());
+        if ($mimeType !== 'image/gif') {
+            return false;
+        }
+
+        $fileContents = $asset->getContents();
+        return substr_count($fileContents, "\x21\xF9\x04") > 1;
+    }
+
+    /**
+     * Checks if a specific MIME type is supported by AI Vision bounds limit mappings
+     *
+     * @param string $mimeType
+     * @return bool
+     */
+    protected function isAcceptedMimeType(string $mimeType): bool
+    {
+        return in_array(strtolower($mimeType), self::ACCEPTED_MIME_TYPES);
+    }
+
+    /**
+     * Checks if the asset format requires conversion to a natively supported format (JPEG/PNG).
+     *
+     * @param Asset $asset The asset to check
+     * @return bool
+     */
+    protected function needsFormatConversion(Asset $asset): bool
+    {
+        return !$this->isAcceptedMimeType($asset->getMimeType());
+    }
+
+    /**
+     * Downloads an asset or transform URL via Guzzle and returns its base64 encoded string.
+     * Falls back to returning the original asset contents as base64 if the URL cannot be fetched.
+     *
+     * @param Asset $asset The original asset
+     * @param string|null $imageUrl The target URL (often a temporary transformed URL)
+     * @param array $transformParams The params applied, used for log context
+     * @return string The base64 encoded data
+     */
+    protected function getAssetBase64String(Asset $asset, ?string $imageUrl, array $transformParams = []): string
+    {
+        // Always try to fetch the transformed or public URL using Guzzle to get the resized contents
+        if (!empty($imageUrl)) {
+            try {
+                $response = $this->client->get($imageUrl);
+                if ($response->getStatusCode() === 200) {
+                    $assetContents = (string)$response->getBody();
+                    return base64_encode($assetContents);
+                }
+            } catch (Exception|GuzzleException $e) {
+                Craft::warning('Failed to download image URL for Base64 conversion: ' . $e->getMessage(), __METHOD__);
+            }
+        }
+
+        if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
+            
+            if ($this->needsFormatConversion($asset)) {
+                $assetMimeType = strtolower($asset->getMimeType());
+                // See https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148
+                Craft::warning("Asset {$asset->filename} has no URL and an unsupported MIME type \"$assetMimeType\". A transform is required but retrieving the file contents for a transform is unsupported. Continuing with source asset file contents for base64 encoding just incase it is accepted...", __METHOD__);
+            }
+            
+            if (!empty($transformParams)) {
+                Craft::warning("Asset {$asset->filename} has no URL and requires a transform, but retrieving the file contents for a transform is unsupported. Continuing with source asset file contents for base64 encoding just incase it is accepted...", __METHOD__);
+            }
+        } else {
+            // URL existed but Guzzle still failed to download it for encoding
+            Craft::warning("API Request: Download failed for image {$asset->filename}. Using original, un-scaled asset file contents for base64 encoding.", __METHOD__);
+        }
+
+        return base64_encode($asset->getContents());
+    }
+
+    /**
+     * Generates a standardized array of transform parameters across AI Vision boundaries.
+     * Handles unsupported MIME type fallback conversions (SVG/WEBP to PNG/JPG) and dimensional bounding.
+     *
+     * @param Asset $asset The original asset
+     * @param int|null $maxLongEdge The maximum allowed length for the longest edge of the image
+     * @param int $maxFileSizeMb The maximum file size in MB before a quality reduction is forced
+     * @param int|null $maxPatches OpenAI tile budget — total 512px patch count ceiling (e.g. ceil(w/32)*ceil(h/32))
+     * @param int|null $maxTokens Claude token budget — total pixel-area token ceiling (e.g. (w*h)/750)
+     * @return array The calculated transform params suited for Craft's transform engine
+     */
+    protected function getVisionTransformParams(Asset $asset, ?int $maxLongEdge = null, int $maxFileSizeMb = 20, ?int $maxPatches = null, ?int $maxTokens = null): array
+    {
+        $assetMimeType = strtolower($asset->getMimeType());
+        
+        // Set up transform parameters
+        $transformParams = [];
+        
+        // decide if we need to transform the image to become a jpeg
+        $needsFormatConversion = $this->needsFormatConversion($asset);
+        
+        // Always convert format if needed, regardless of dimensions
+        if ($needsFormatConversion) {
+            // @todo check if webp is supported by the environment and use that and fall back to jpg
+            $transformParams['format'] = 'jpg';
+            
+            // check the image is a svg and fallback to transform to a png for transparency support
+            if ($assetMimeType === 'image/svg+xml') {
+                // @todo use webp and fallback to png for transparent images where webp is not supported
+                $transformParams['format'] = 'png';
+            }
+        }
+        
+        // Animated GIFs need to be converted to a static format (extracts first frame)
+        if ($this->isAnimatedGif($asset)) {
+            Craft::warning("Asset {$asset->filename} is an animated GIF. Converting to JPG to extract the first frame for AI Vision analysis.", __METHOD__);
+            $transformParams['format'] = 'jpg';
+        }
+        
+        // Get original image dimensions
+        $width = $asset->getWidth();
+        $height = $asset->getHeight();
+        
+        // Cap the longest edge if it exceeds the provider's limit, Craft's 'fit' mode will preserve the aspect ratio
+        if ($maxLongEdge !== null && ($width > $maxLongEdge || $height > $maxLongEdge)) {
+            if ($width >= $height) {
+                // Wide/square image: cap the width
+                $transformParams['width'] = $maxLongEdge;
+            } else {
+                // Tall image: cap the height
+                $transformParams['height'] = $maxLongEdge;
+            }
+        }
+        
+        // OpenAI patch budget: if the image would produce more tiles than allowed, scale down proportionally
+        if ($maxPatches !== null) {
+            $patchCount = ceil($width / 32) * ceil($height / 32);
+            if ($patchCount > $maxPatches) {
+                // Calculate scale factor to fit within patch budget
+                $scaleFactor = sqrt($maxPatches / $patchCount);
+                $scaledLongEdge = (int) floor(max($width, $height) * $scaleFactor);
+                
+                if ($width >= $height) {
+                    $transformParams['width'] = $scaledLongEdge;
+                } else {
+                    $transformParams['height'] = $scaledLongEdge;
+                }
+            }
+        }
+        
+        // Claude token budget: if the pixel area would exceed the token limit, scale down proportionally
+        if ($maxTokens !== null) {
+            $tokenCount = ($width * $height) / 750;
+            if ($tokenCount > $maxTokens) {
+                // Calculate scale factor to fit within token budget
+                $scaleFactor = sqrt(($maxTokens * 750) / ($width * $height));
+                $scaledLongEdge = (int) floor(max($width, $height) * $scaleFactor);
+                
+                if ($width >= $height) {
+                    $transformParams['width'] = $scaledLongEdge;
+                } else {
+                    $transformParams['height'] = $scaledLongEdge;
+                }
+            }
+        }
+        
+        // If the file exceeds the provider's max payload and no other transform has been set, reduce quality
+        if (empty($transformParams) && $asset->size > $maxFileSizeMb * 1024 * 1024) {
+            Craft::info("{$asset->filename} is larger than {$maxFileSizeMb}MB, setting transform quality to 75", __METHOD__);
+            $transformParams['quality'] = 75;
+        }
+        
+        // Set mode fit for all transforms, done here so that the array evaluates to empty if no resizing or formatting occurs
+        if (!empty($transformParams)) {
+            $transformParams['mode'] = 'fit';
+        }
+
+        return $transformParams;
+    }
+}

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -171,7 +171,7 @@ abstract class ApiService extends Component
      * @param int|null $maxLongEdge The maximum allowed length for the longest edge of the image
      * @param int $maxFileSizeMb The maximum file size in MB before a quality reduction is forced
      * @param int|null $maxPatches OpenAI tile budget — total 512px patch count ceiling (e.g. ceil(w/32)*ceil(h/32))
-     * @param int|null $maxTokens Claude token budget — total pixel-area token ceiling (e.g. (w*h)/750)
+     * @param int|null $maxTokens Anthropic token budget — total pixel-area token ceiling (e.g. (w*h)/750)
      * @return array The calculated transform params suited for Craft's transform engine
      */
     protected function getVisionTransformParams(Asset $asset, ?int $maxLongEdge = null, int $maxFileSizeMb = 20, ?int $maxPatches = null, ?int $maxTokens = null): array
@@ -233,7 +233,7 @@ abstract class ApiService extends Component
             }
         }
         
-        // Claude token budget: if the pixel area would exceed the token limit, scale down proportionally
+        // Anthropic token budget: if the pixel area would exceed the token limit, scale down proportionally
         if ($maxTokens !== null) {
             $tokenCount = ($width * $height) / 750;
             if ($tokenCount > $maxTokens) {

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -8,6 +8,7 @@ use craft\elements\Asset;
 use craft\errors\AssetException;
 use craft\errors\ImageTransformException;
 use craft\helpers\App;
+use craft\helpers\Json;
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
@@ -60,7 +61,7 @@ class OpenAiService extends ApiService
     {
         try {
             // Log the request for debugging
-            Craft::info('OpenAI API request: ' . json_encode($requestData), __METHOD__);
+            Craft::info('OpenAI API request: ' . Json::encode($requestData), __METHOD__);
 
             $response = $this->client->post($this->baseUrl . '/responses', [
                 'headers' => [
@@ -87,7 +88,7 @@ class OpenAiService extends ApiService
 
             // Make sure the response model is valid
             if (!$responseModel->validate()) {
-                $errorMsg = 'Response validation failed: ' . json_encode($responseModel->getErrors());
+                $errorMsg = 'Response validation failed: ' . Json::encode($responseModel->getErrors());
                 Craft::warning($errorMsg, __METHOD__);
                 // Set error if not already set
                 if (!$responseModel->hasError()) {
@@ -223,7 +224,7 @@ class OpenAiService extends ApiService
 
         // Validate the request
         if (!$request->validate()) {
-            throw new Exception('Invalid request: ' . json_encode($request->getErrors()));
+            throw new Exception('Invalid request: ' . Json::encode($request->getErrors()));
         }
 
         // Convert to array explicitly to avoid potential object-to-array conversion issues

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -26,7 +26,7 @@ use yii\base\InvalidConfigException;
  * @property string $model The OpenAI model to use
  * @property string $baseUrl The base URL for OpenAI API requests
  */
-class OpenAiService extends Component
+class OpenAiService extends ApiService
 {
     private string $apiKey;
     private string $model;
@@ -56,15 +56,13 @@ class OpenAiService extends Component
      * @return OpenAiResponse The API response
      * @throws Exception|GuzzleException If the API call fails
      */
-    public function sendRequest(array $requestData): OpenAiResponse
+    private function sendRequest(array $requestData): OpenAiResponse
     {
-        $client = Craft::createGuzzleClient();
-
         try {
             // Log the request for debugging
             Craft::info('OpenAI API request: ' . json_encode($requestData), __METHOD__);
 
-            $response = $client->post($this->baseUrl . '/responses', [
+            $response = $this->client->post($this->baseUrl . '/responses', [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $this->apiKey,
                     'Content-Type' => 'application/json',
@@ -127,64 +125,7 @@ class OpenAiService extends Component
         }
     }
 
-    /**
-     * Checks if a URL is accessible remotely
-     *
-     * @param string $url The URL to check
-     * @return bool Whether the URL is accessible
-     * @throws GuzzleException
-     */
-    private function isUrlAccessible(string $url): bool
-    {
-        try {
-            $client = Craft::createGuzzleClient();
-            $response = $client->head($url, [
-                'timeout' => 5,
-                'connect_timeout' => 5,
-                'allow_redirects' => true,
-            ]);
-            return $response->getStatusCode() === 200;
-        } catch (Exception $e) {
-            Craft::warning('URL accessibility check failed: ' . $e->getMessage(), __METHOD__);
-            return false;
-        }
-    }
 
-    /**
-     * Validates if the asset is an accepted image format and converts if needed
-     *
-     * @param Asset $asset The asset to validate
-     * @return bool Whether the asset is an accepted mimetype or was successfully converted
-     * @throws ImageTransformException
-     */
-    private function isValidImageFormat(Asset $asset): bool
-    {
-        $mimeType = strtolower($asset->getMimeType());
-
-        // Check for accepted MIME types
-        $acceptedMimeTypes = [
-            'image/png',
-            'image/jpeg',
-            'image/webp',
-            'image/gif'
-        ];
-
-        if (!in_array($mimeType, $acceptedMimeTypes)) {
-            Craft::warning('Asset has unsupported MIME type: ' . $mimeType . '. Will attempt to convert to JPEG.', __METHOD__);
-            return true; // We'll handle conversion in generateAltText
-        }
-
-        // For GIFs, check if they're animated
-        if ($mimeType === 'image/gif') {
-            $fileContents = $asset->getContents();
-            // Check for multiple image frames in GIF
-            if (substr_count($fileContents, "\x21\xF9\x04") > 1) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 
     /**
      * Generates alt text for an asset using OpenAI's vision model
@@ -204,82 +145,24 @@ class OpenAiService extends Component
      * @throws InvalidConfigException
      * @throws Exception
      */
-    public function generateAltText(Asset $asset, int $siteId = null): string
+    public function generateAltText(Asset $asset, ?int $siteId = null): string
     {
-        // Validate image format first
-        if (!$this->isValidImageFormat($asset)) {
-            throw new Exception('Asset is not in a supported image format. Supported formats are: PNG, JPEG, WEBP, and non-animated GIF.');
+        // Validate image support using the parent base service method
+        $this->validateImageSupport($asset);
+
+        // OpenAI Vision: max 2048px long edge (API handles short edge scaling internally), max 20MB payload
+        // Patch budget based on detail:high tiling — each 512px tile costs 170 tokens + 85 base
+        $transformParams = $this->getVisionTransformParams($asset, maxLongEdge: 2048, maxFileSizeMb: 20, maxPatches: 1536);
+
+        if (!empty($transformParams)) {
+            $asset->setTransform($transformParams);
         }
-
-        // Get original image dimensions
-        $width = $asset->getWidth();
-        $height = $asset->getHeight();
-
-        // Check if format needs to be converted
-        $acceptedMimeTypes = [
-            'image/png',
-            'image/jpeg',
-            'image/webp',
-            'image/gif',
-        ];
-        $assetMimeType = strtolower($asset->getMimeType());
-
-        // Check if the asset is an animated gif which OpenAI API does not support
-        if ($assetMimeType === 'image/gif') {
-            $fileContents = $asset->getContents();
-            // Check for multiple image frames in GIF
-            if (substr_count($fileContents, "\x21\xF9\x04") > 1) {
-                throw new Exception('Animated GIF detected, this is not supported.');
-            }
-        }
-        
-        // decide if we need to transform svgs
-        if (!Craft::$app->getConfig()->getGeneral()->transformSvgs && $assetMimeType === 'image/svg+xml') {
-            throw new Exception('SVGs are not supported by the OpenAI API and transformSvgs is disabled.');
-        }
-
-        // decide if we need to transform the image to become a jpeg
-        $needsFormatConversion = !in_array($assetMimeType, $acceptedMimeTypes);
-
-        // Set up transform parameters
-        $transformParams = [];
-
-        // Always convert format if needed, regardless of dimensions
-        if ($needsFormatConversion) {
-            // @todo check if webp is supported by the environment and use that and fall back to jpg
-            $transformParams['format'] = 'jpg';
-
-            // check the image is a svg and fallback to transform to a png for transparency support
-            if ($assetMimeType === 'image/svg+xml') {
-                // @todo use webp and fallback to png for transparent images where webp is not supported
-                $transformParams['format'] = 'png';
-            }
-        }
-
-        // If width is larger than height and width is larger than 2000px set transform params
-        if ($width >= $height && ($width > 2000 || $height > 768)) {
-            $transformParams['width'] = 2000;
-            $transformParams['height'] = 768;
-            $transformParams['mode'] = 'fit';
-        } elseif ($height >= $width && ($height > 2000 || $width > 768)) {
-            $transformParams['width'] = 768;
-            $transformParams['height'] = 2000;
-            $transformParams['mode'] = 'fit';
-        }
-        
-        // Very unlikely a 20MB file will be under 2000x768, but just in case lets set the quality to 75 to mitigate the risk of that scenario
-        if (empty($transformParams) && $asset->size >  20 * 1024 * 1024) {
-            Craft::info("$asset->filename is 20MB file detected setting transform quality to 75", __METHOD__);
-            $transformParams['quality'] = 75;
-        }
-
-        // Set the transform
-        $asset->setTransform($transformParams);
 
         // Check mime type of the transform:
         $transformMimeType = $asset->getMimeType($transformParams);
-        if (!in_array($transformMimeType, $acceptedMimeTypes)) {
-            Craft::warning("Asset transform has unsupported MIME type: $transformMimeType, continuing with source asset...", __METHOD__);
+        
+        if (!$this->isAcceptedMimeType($transformMimeType)) {
+            throw new Exception("Asset transform produced unsupported MIME type: $transformMimeType. Supported formats are: " . implode(', ', self::ACCEPTED_MIME_TYPES));
         }
         
         // Make sure that we do not get a "generate transform" url, but a real url with true
@@ -295,22 +178,14 @@ class OpenAiService extends Component
 
         // If no public URL is available or URL is not accessible, try to get the file contents and encode as base64
         if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
-            if ($needsFormatConversion) {
-                // See https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148
-                Craft::warning("Asset $asset->filename has no URL and an unsupported MIME type \"$assetMimeType\". A transform is required but retrieving the file contents for a transform is unsupported. Continuing with source asset file contents for base64 encoding just incase it is accepted...", __METHOD__);
-            }
-            if (!empty($transformParams)) {
-                Craft::warning("Asset $asset->filename has no URL and requires a transform, but retrieving the file contents for a transform is unsupported. Continuing with source asset file contents for base64 encoding just incase it is accepted...", __METHOD__);
-            }
-            $assetContents = $asset->getContents();
-
-            // Encode as base64 and create data URI
-            $base64Image = base64_encode($assetContents);
+            $base64Image = $this->getAssetBase64String($asset, $imageUrl, $transformParams);
             $imageUrl = "data:$transformMimeType;base64,$base64Image";
         }
 
         // Only set detail parameter for images larger than 512x512 pixels
         // OpenAI API doesn't accept detail parameter for smaller images
+        $width = $asset->getWidth();
+        $height = $asset->getHeight();
         $detail = null;
         if ($width > 512 || $height > 512) {
             $detail = App::parseEnv(AiAltText::getInstance()->getSettings()->openAiImageInputDetailLevel) ?? 'low';
@@ -328,15 +203,9 @@ class OpenAiService extends Component
         $site = Craft::$app->getSites()->getSiteById($siteId);
 
         // parse $prompt for {site.param} and replace with $site->param
-        // make sure that if the string may contain "{site.title}{site.caption}" we only replace each occurrence, and do not capture "{site.title}{site.caption}"
         $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
             return $site->{$matches[1]};
         }, $prompt);
-
-        // Make sure we have a valid prompt
-        if (empty($prompt)) {
-            $prompt = 'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}';
-        }
 
         // Log asset info for debugging
         Craft::info('Generating alt text for asset: ' . $asset->filename . ' (' . $imageUrl . ')', __METHOD__);

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -3,18 +3,14 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
+use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
-use craft\errors\AssetException;
-use craft\errors\ImageTransformException;
-use craft\helpers\App;
-use craft\helpers\Json;
-use Exception;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
+use craft\errors\{AssetException, ImageTransformException};
+use craft\helpers\{App, Json};
+use GuzzleHttp\Exception\{GuzzleException, RequestException};
 use heavymetalavo\craftaialttext\AiAltText;
-use heavymetalavo\craftaialttext\models\api\OpenAiRequest;
-use heavymetalavo\craftaialttext\models\api\OpenAiResponse;
+use heavymetalavo\craftaialttext\models\api\{OpenAiRequest, OpenAiResponse};
 use yii\base\InvalidConfigException;
 
 /**
@@ -41,8 +37,9 @@ class OpenAiService extends ApiService
     public function __construct()
     {
         parent::__construct();
-        $this->apiKey = App::parseEnv(AiAltText::getInstance()->getSettings()->openAiApiKey);
-        $this->model = App::parseEnv(AiAltText::getInstance()->getSettings()->openAiModel);
+        $plugin = AiAltText::getInstance();
+        $this->apiKey = App::parseEnv($plugin->getSettings()->openAiApiKey);
+        $this->model = App::parseEnv($plugin->getSettings()->openAiModel);
     }
 
     /**
@@ -148,6 +145,7 @@ class OpenAiService extends ApiService
      */
     public function generateAltText(Asset $asset, ?int $siteId = null): string
     {
+        $plugin = AiAltText::getInstance();
         // Validate image support using the parent base service method
         $this->validateImageSupport($asset);
 
@@ -189,10 +187,10 @@ class OpenAiService extends ApiService
         $height = $asset->getHeight();
         $detail = null;
         if ($width > 512 || $height > 512) {
-            $detail = App::parseEnv(AiAltText::getInstance()->getSettings()->openAiImageInputDetailLevel) ?? 'low';
+            $detail = App::parseEnv($plugin->getSettings()->openAiImageInputDetailLevel) ?? 'low';
         }
         
-        $prompt = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
+        $prompt = App::parseEnv($plugin->getSettings()->prompt);
 
         // parse $prompt for {asset.param} and replace with $asset->param
         // make sure that if the string may contain "{asset.title}{asset.caption}" we only replace each occurrence, and do not capture "{asset.title}{asset.caption}"

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -239,7 +239,7 @@ class OpenAiService extends ApiService
         }
 
         // If output is empty, log and return empty string
-        if (empty($response->output_text)) {
+        if (empty($response->outputText)) {
             Craft::warning('No alt text was generated for asset: ' . $asset->filename, __METHOD__);
             return '';
         }

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -3,11 +3,11 @@
 namespace heavymetalavo\craftaialttext\services;
 
 use Craft;
-use Exception;
 use craft\base\Component;
 use craft\elements\Asset;
 use craft\errors\{AssetException, ImageTransformException};
 use craft\helpers\{App, Json};
+use Exception;
 use GuzzleHttp\Exception\{GuzzleException, RequestException};
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\models\api\{OpenAiRequest, OpenAiResponse};

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -76,7 +76,6 @@
         name: 'anthropicImageDetailLevel',
         instructions: "Pre-scale the image to reduce [token cost and latency](https://platform.claude.com/docs/en/build-with-claude/vision#evaluate-image-size)."|t("aialttext"),
         options: [
-            { label: 'Very Low (300px x 300px)', value: 'veryLow' },
             { label: 'Low (500px x 500px)', value: 'low' },
             { label: 'Medium (1000px x 1000px)', value: 'medium' },
             { label: 'High (1568px x 1568px)', value: 'high' }

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -143,7 +143,7 @@
     label: 'Prompt'|t('app'),
     id: 'prompt',
     name: 'prompt',
-    instructions: "The text prompt which will be sent to the AI provider with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}, checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template.`"|t("aialttext"),
+    instructions: "The text prompt which will be sent to the AI provider with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`, checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template.`"|t("aialttext"),
     value: settings.prompt,
     placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.language}",
     errors: settings.getErrors('prompt'),

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -71,7 +71,7 @@
     name: 'anthropicImageDetailLevel',
     instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
     options: [
-        { label: 'Very Low (300px x 300px)', value: 'very_low' },
+        { label: 'Very Low (300px x 300px)', value: 'veryLow' },
         { label: 'Low (500px x 500px)', value: 'low' },
         { label: 'Medium (1000px x 1000px)', value: 'medium' },
         { label: 'High (1568px x 1568px)', value: 'high' }

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -136,7 +136,7 @@
 {{ forms.lightswitchField({
     label: 'Propagate'|t('aialttext'),
     id: 'propagate',
-    name: ' ',
+    name: 'propagate',
     instructions: "Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites."|t("aialttext"),
     on: settings.propagate,
     errors: settings.getErrors('propagate'),

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -42,33 +42,33 @@
 <hr />
 
 <div id="settings-provider-anthropic">
-<h3>Anthropic Claude Settings</h3>
+<h3>Anthropic Settings</h3>
 
 {{ forms.autosuggestField({
-    label: "Claude API Key"|t("aialttext"),
+    label: "Anthropic API Key"|t("aialttext"),
     instructions: "The API key from your [Anthropic Console account](https://console.anthropic.com/)"|t("aialttext"),
-    id: "claudeApiKey",
-    name: "claudeApiKey",
+    id: "anthropicApiKey",
+    name: "anthropicApiKey",
     suggestEnvVars: true,
-    value: settings.claudeApiKey,
-    errors: settings.getErrors("claudeApiKey"),
+    value: settings.anthropicApiKey,
+    errors: settings.getErrors("anthropicApiKey"),
 }) }}
 
 {{ forms.autosuggestField({
-    label: 'Claude Model'|t('aialttext'),
-    id: 'claudeModel',
-    name: 'claudeModel',
-    instructions: "The Anthropic Claude model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
-    value: settings.claudeModel,
+    label: 'Anthropic Model'|t('aialttext'),
+    id: 'anthropicModel',
+    name: 'anthropicModel',
+    instructions: "The Anthropic model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
+    value: settings.anthropicModel,
     placeholder: 'claude-haiku-4-5',
-    errors: settings.getErrors('claudeModel'),
+    errors: settings.getErrors('anthropicModel'),
     suggestEnvVars: true,
 }) }}
 
 {{ forms.selectField({
-    label: 'Claude Image Input Detail Level'|t('app'),
-    id: 'claudeImageDetailLevel',
-    name: 'claudeImageDetailLevel',
+    label: 'Anthropic Image Detail Level'|t('app'),
+    id: 'anthropicImageDetailLevel',
+    name: 'anthropicImageDetailLevel',
     instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
     options: [
         { label: 'Very Low (300px x 300px)', value: 'very_low' },
@@ -76,8 +76,8 @@
         { label: 'Medium (1000px x 1000px)', value: 'medium' },
         { label: 'High (1568px x 1568px)', value: 'high' }
     ],
-    value: settings.claudeImageDetailLevel,
-    errors: settings.getErrors('claudeImageDetailLevel')
+    value: settings.anthropicImageDetailLevel,
+    errors: settings.getErrors('anthropicImageDetailLevel')
 }) }}
 </div>
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -143,9 +143,9 @@
     label: 'Prompt'|t('app'),
     id: 'prompt',
     name: 'prompt',
-    instructions: "The text prompt which will be sent to the AI with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`"|t("aialttext"),
+    instructions: "The text prompt which will be sent to the AI provider with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}, checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template.`"|t("aialttext"),
     value: settings.prompt,
-    placeholder: "Describe the image provided, make it suitable for an alt text description. Output in {site.language}",
+    placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.language}",
     errors: settings.getErrors('prompt'),
 }) }}
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -21,6 +21,8 @@
 </ol>
 
 
+<hr />
+
 
 <h2 id="settings">Settings</h2>
 
@@ -42,94 +44,98 @@
 <hr />
 
 <div id="settings-provider-anthropic">
-<h3>Anthropic Settings</h3>
+    <h3>Anthropic Settings</h3>
 
-{{ forms.autosuggestField({
-    label: "Anthropic API Key"|t("aialttext"),
-    instructions: "The API key from your [Anthropic Console account](https://console.anthropic.com/)"|t("aialttext"),
-    id: "anthropicApiKey",
-    name: "anthropicApiKey",
-    suggestEnvVars: true,
-    value: settings.anthropicApiKey,
-    errors: settings.getErrors("anthropicApiKey"),
-}) }}
+    {{ forms.autosuggestField({
+        label: "Anthropic API Key"|t("aialttext"),
+        instructions: "The API key from your [Anthropic Console account](https://console.anthropic.com/)"|t("aialttext"),
+        id: "anthropicApiKey",
+        name: "anthropicApiKey",
+        placeholder: '$ANTHROPIC_API_KEY',
+        suggestEnvVars: true,
+        value: settings.anthropicApiKey,
+        errors: settings.getErrors("anthropicApiKey"),
+    }) }}
 
-{{ forms.autosuggestField({
-    label: 'Anthropic Model'|t('aialttext'),
-    id: 'anthropicModel',
-    name: 'anthropicModel',
-    instructions: "The Anthropic model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
-    value: settings.anthropicModel,
-    placeholder: 'claude-haiku-4-5',
-    errors: settings.getErrors('anthropicModel'),
-    suggestEnvVars: true,
-}) }}
+    {{ forms.autosuggestField({
+        label: 'Anthropic Model'|t('aialttext'),
+        id: 'anthropicModel',
+        name: 'anthropicModel',
+        instructions: "The Anthropic model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
+        value: settings.anthropicModel,
+        placeholder: 'claude-haiku-4-5',
+        errors: settings.getErrors('anthropicModel'),
+        suggestEnvVars: true,
+    }) }}
 
-{{ forms.selectizeField({
-    label: 'Anthropic Image Detail Level'|t('aialttext'),
-    id: 'anthropicImageDetailLevel',
-    name: 'anthropicImageDetailLevel',
-    instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
-    options: [
-        { label: 'Very Low (300px x 300px)', value: 'veryLow' },
-        { label: 'Low (500px x 500px)', value: 'low' },
-        { label: 'Medium (1000px x 1000px)', value: 'medium' },
-        { label: 'High (1568px x 1568px)', value: 'high' }
-    ],
-    includeEnvVars: true,
-    allowedEnvValues: null,
-    value: settings.anthropicImageDetailLevel,
-    errors: settings.getErrors('anthropicImageDetailLevel')
-}) }}
+    {{ forms.selectizeField({
+        label: 'Anthropic Image Detail Level'|t('aialttext'),
+        id: 'anthropicImageDetailLevel',
+        name: 'anthropicImageDetailLevel',
+        instructions: "Pre-scale the image to reduce [token cost and latency](https://platform.claude.com/docs/en/build-with-claude/vision#evaluate-image-size)."|t("aialttext"),
+        options: [
+            { label: 'Very Low (300px x 300px)', value: 'veryLow' },
+            { label: 'Low (500px x 500px)', value: 'low' },
+            { label: 'Medium (1000px x 1000px)', value: 'medium' },
+            { label: 'High (1568px x 1568px)', value: 'high' }
+        ],
+        includeEnvVars: true,
+        allowedEnvValues: null,
+        value: settings.anthropicImageDetailLevel,
+        errors: settings.getErrors('anthropicImageDetailLevel')
+    }) }}
 </div>
 
 
-
 <hr />
+
 
 <div id="settings-provider-openai">
-<h3>OpenAI Settings</h3>
+    <h3>OpenAI Settings</h3>
 
-{{ forms.autosuggestField({
-    label: "OpenAI API Key"|t("aialttext"),
-    instructions: "The API key from your Open AI account"|t("aialttext"),
-    id: "openAiApiKey",
-    name: "openAiApiKey",
-    suggestEnvVars: true,
-    value: settings.openAiApiKey,
-    errors: settings.getErrors("openAiApiKey"),
-}) }}
+    {{ forms.autosuggestField({
+        label: "OpenAI API Key"|t("aialttext"),
+        instructions: "The API key from your Open AI account"|t("aialttext"),
+        id: "openAiApiKey",
+        name: "openAiApiKey",
+        placeholder: '$OPENAI_API_KEY',
+        suggestEnvVars: true,
+        value: settings.openAiApiKey,
+        errors: settings.getErrors("openAiApiKey"),
+    }) }}
 
-{{ forms.autosuggestField({
-    label: 'Open AI Model'|t('app'),
-    id: 'openAiModel',
-    name: 'openAiModel',
-    instructions: "The OpenAI model used to generate the response. To find out which models are capable of vision OpenAI suggest to look [on the models page](https://platform.openai.com/docs/models) E.g., `gpt-5-nano`."|t("aialttext"),
-    value: settings.openAiModel,
-    placeholder: 'gpt-5-nano',
-    errors: settings.getErrors('openAiModel'),
-    suggestEnvVars: true,
-}) }}
+    {{ forms.autosuggestField({
+        label: 'Open AI Model'|t('app'),
+        id: 'openAiModel',
+        name: 'openAiModel',
+        instructions: "The OpenAI model used to generate the response. To find out which models are capable of vision OpenAI suggest to look [on the models page](https://platform.openai.com/docs/models) E.g., `gpt-5-nano`."|t("aialttext"),
+        value: settings.openAiModel,
+        placeholder: 'gpt-5-nano',
+        errors: settings.getErrors('openAiModel'),
+        suggestEnvVars: true,
+    }) }}
 
-{{ forms.selectizeField({
-    label: 'OpenAI Image Detail Level'|t('aialttext'),
-    id: 'openAiImageInputDetailLevel',
-    name: 'openAiImageInputDetailLevel',
-    instructions: "Specify the [Image input detail level](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#specify-image-input-detail-level), `low` costs the least at 85 tokens."|t("aialttext"),
-    options: [
-        { label: 'Low — Fast, low-cost (512px x 512px)', value: 'low' },
-        { label: 'High — Standard high-fidelity understanding', value: 'high' },
-        { label: 'Original — Large, dense, spatially sensitive images (gpt-5.4+)', value: 'original' },
-        { label: 'Auto — Let the model choose', value: 'auto' }
-    ],
-    includeEnvVars: true,
-    allowedEnvValues: null,
-    value: settings.openAiImageInputDetailLevel,
-    errors: settings.getErrors('openAiImageInputDetailLevel')
-}) }}
+    {{ forms.selectizeField({
+        label: 'OpenAI Image Detail Level'|t('aialttext'),
+        id: 'openAiImageInputDetailLevel',
+        name: 'openAiImageInputDetailLevel',
+        instructions: "Controls the [detail level](https://developers.openai.com/api/docs/guides/images-vision#choose-an-image-detail-level) used when OpenAI is processing the image."|t("aialttext"),
+        options: [
+            { label: 'Low - Fast, low-cost (512px x 512px)', value: 'low' },
+            { label: 'High - Standard high-fidelity understanding', value: 'high' },
+            { label: 'Original - Large, dense, spatially sensitive images (gpt-5.4+)', value: 'original' },
+            { label: 'Auto - Let the model choose', value: 'auto' }
+        ],
+        includeEnvVars: true,
+        allowedEnvValues: null,
+        value: settings.openAiImageInputDetailLevel,
+        errors: settings.getErrors('openAiImageInputDetailLevel')
+    }) }}
 </div>
 
+
 <hr />
+
 
 {{ forms.textareaField({
     label: 'Prompt'|t('app'),

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -7,8 +7,8 @@
 <p>Lots of info in <a target="_blank" href="https://github.com/heavymetalavo/craft-aialttext">the plugin docs</a>, but a short summary;
 <ol>
     <li>Check the plugin settings are suitable for your project (and your API key is added)</li>
-    <li>Ensure your volumes have the native `alt` field assigned to the field layout</li>
-    <li>Ensure your templates are updated to use the `alt` field, you could consider a fallback `asset.alt ?: asset.title` if that what was used before</li>
+    <li>Ensure your volumes have <a href="https://docs.craftcms.com/api/v5/craft-fieldlayoutelements-assets-altfield.html#altfield" target="_blank">the native alt field</a> assigned to the field layout</li>
+    <li><p>Ensure your templates are updated to use the <code>alt</code> field, you could consider a fallback <code>asset.alt ?: asset.title</code> if that what was used before</p></li>
     <li>Then generate some AI Alt text by performing one of the following actions:
         <ol>
             <li>Triggering a bulk action in the <a href="{{ cpUrl('utilities/ai-alt-text-bulk-actions') }}">bulk actions utility</a></li>
@@ -24,49 +24,51 @@
 
 <h2 id="settings">Settings</h2>
 
-{{ forms.selectField({
+{{ forms.selectizeField({
     label: "AI Provider"|t("aialttext"),
     instructions: "Choose which AI service to use for generating alt text"|t("aialttext"),
     id: "aiProvider",
     name: "aiProvider",
     options: [
-        { label: 'Anthropic Claude', value: 'anthropic' },
+        { label: 'Anthropic', value: 'anthropic' },
         { label: 'OpenAI', value: 'openai' }
     ],
+    includeEnvVars: true,
+    allowedEnvValues: null,
     value: settings.aiProvider,
-    errors: settings.getErrors("aiProvider"),
-    toggle: true,
-    targetPrefix: 'provider-'
+    errors: settings.getErrors("aiProvider")
 }) }}
 
-<div id="provider-anthropic" {% if settings.aiProvider != 'anthropic' %}class="hidden"{% endif %}>
+<hr />
+
+<div id="settings-provider-anthropic">
 <h3>Anthropic Claude Settings</h3>
 
 {{ forms.autosuggestField({
-    label: "Anthropic API Key"|t("aialttext"),
+    label: "Claude API Key"|t("aialttext"),
     instructions: "The API key from your [Anthropic Console account](https://console.anthropic.com/)"|t("aialttext"),
-    id: "anthropicApiKey",
-    name: "anthropicApiKey",
+    id: "claudeApiKey",
+    name: "claudeApiKey",
     suggestEnvVars: true,
-    value: settings.anthropicApiKey,
-    errors: settings.getErrors("anthropicApiKey"),
+    value: settings.claudeApiKey,
+    errors: settings.getErrors("claudeApiKey"),
 }) }}
 
 {{ forms.autosuggestField({
-    label: 'Anthropic Model'|t('aialttext'),
-    id: 'anthropicModel',
-    name: 'anthropicModel',
+    label: 'Claude Model'|t('aialttext'),
+    id: 'claudeModel',
+    name: 'claudeModel',
     instructions: "The Anthropic Claude model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
-    value: settings.anthropicModel,
+    value: settings.claudeModel,
     placeholder: 'claude-haiku-4-5',
-    errors: settings.getErrors('anthropicModel'),
+    errors: settings.getErrors('claudeModel'),
     suggestEnvVars: true,
 }) }}
 
 {{ forms.selectField({
-    label: 'Anthropic Image Input Detail Level'|t('app'),
-    id: 'anthropicImageDetailLevel',
-    name: 'anthropicImageDetailLevel',
+    label: 'Claude Image Input Detail Level'|t('app'),
+    id: 'claudeImageDetailLevel',
+    name: 'claudeImageDetailLevel',
     instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
     options: [
         { label: 'Very Low (300px x 300px)', value: 'very_low' },
@@ -74,14 +76,16 @@
         { label: 'Medium (1000px x 1000px)', value: 'medium' },
         { label: 'High (1568px x 1568px)', value: 'high' }
     ],
-    value: settings.anthropicImageDetailLevel,
-    errors: settings.getErrors('anthropicImageDetailLevel')
+    value: settings.claudeImageDetailLevel,
+    errors: settings.getErrors('claudeImageDetailLevel')
 }) }}
 </div>
 
 
 
-<div id="provider-openai" {% if settings.aiProvider != 'openai' %}class="hidden"{% endif %}>
+<hr />
+
+<div id="settings-provider-openai">
 <h3>OpenAI Settings</h3>
 
 {{ forms.autosuggestField({
@@ -156,15 +160,6 @@
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}
 
-{% js %}
-window.addEventListener('pageshow', function (event) {
-    if (event.persisted) {
-        var providerSelect = document.querySelector('select[name="aiProvider"]');
-        if (providerSelect) {
-            providerSelect.dispatchEvent(new Event('change'));
-        }
-    }
-});
-{% endjs %}
+
 
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -65,8 +65,8 @@
     suggestEnvVars: true,
 }) }}
 
-{{ forms.selectField({
-    label: 'Anthropic Image Detail Level'|t('app'),
+{{ forms.selectizeField({
+    label: 'Anthropic Image Detail Level'|t('aialttext'),
     id: 'anthropicImageDetailLevel',
     name: 'anthropicImageDetailLevel',
     instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
@@ -76,6 +76,8 @@
         { label: 'Medium (1000px x 1000px)', value: 'medium' },
         { label: 'High (1568px x 1568px)', value: 'high' }
     ],
+    includeEnvVars: true,
+    allowedEnvValues: null,
     value: settings.anthropicImageDetailLevel,
     errors: settings.getErrors('anthropicImageDetailLevel')
 }) }}
@@ -109,15 +111,21 @@
     suggestEnvVars: true,
 }) }}
 
-{{ forms.autosuggestField({
-    label: 'Open AI Image Input Detail Level'|t('app'),
+{{ forms.selectizeField({
+    label: 'OpenAI Image Detail Level'|t('aialttext'),
     id: 'openAiImageInputDetailLevel',
     name: 'openAiImageInputDetailLevel',
     instructions: "Specify the [Image input detail level](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#specify-image-input-detail-level), `low` costs the least at 85 tokens."|t("aialttext"),
+    options: [
+        { label: 'Low — Fast, low-cost (512px x 512px)', value: 'low' },
+        { label: 'High — Standard high-fidelity understanding', value: 'high' },
+        { label: 'Original — Large, dense, spatially sensitive images (gpt-5.4+)', value: 'original' },
+        { label: 'Auto — Let the model choose', value: 'auto' }
+    ],
+    includeEnvVars: true,
+    allowedEnvValues: null,
     value: settings.openAiImageInputDetailLevel,
-    placeholder: 'low',
-    errors: settings.getErrors('openAiImageInputDetailLevel'),
-    suggestEnvVars: true,
+    errors: settings.getErrors('openAiImageInputDetailLevel')
 }) }}
 </div>
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -56,9 +56,9 @@
     label: 'Anthropic Model'|t('aialttext'),
     id: 'anthropicModel',
     name: 'anthropicModel',
-    instructions: "The Anthropic Claude model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-3-5-sonnet-latest`."|t("aialttext"),
+    instructions: "The Anthropic Claude model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-haiku-4-5`."|t("aialttext"),
     value: settings.anthropicModel,
-    placeholder: 'claude-3-5-sonnet-latest',
+    placeholder: 'claude-haiku-4-5',
     errors: settings.getErrors('anthropicModel'),
     suggestEnvVars: true,
 }) }}
@@ -69,10 +69,10 @@
     name: 'anthropicImageDetailLevel',
     instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
     options: [
-        { label: 'Very Low (200x200)', value: 'very_low' },
-        { label: 'Low (500x500)', value: 'low' },
-        { label: 'Medium (1000x1000)', value: 'medium' },
-        { label: 'High (1536x1536)', value: 'high' }
+        { label: 'Very Low (300px x 300px)', value: 'very_low' },
+        { label: 'Low (500px x 500px)', value: 'low' },
+        { label: 'Medium (1000px x 1000px)', value: 'medium' },
+        { label: 'High (1568px x 1568px)', value: 'high' }
     ],
     value: settings.anthropicImageDetailLevel,
     errors: settings.getErrors('anthropicImageDetailLevel')

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -11,7 +11,7 @@
     <li>Ensure your templates are updated to use the `alt` field, you could consider a fallback `asset.alt ?: asset.title` if that what was used before</li>
     <li>Then generate some AI Alt text by performing one of the following actions:
         <ol>
-            <li>Triggering a bulk action in the bulk actions table</li>
+            <li>Triggering a bulk action in the <a href="{{ cpUrl('utilities/ai-alt-text-bulk-actions') }}">bulk actions utility</a></li>
             <li>For individual or a group of specific assets find them in the <strong>Assets</strong> manager section</a> clicking the checkbox on a row, clicking the cog icon to reveal the Element actions menu and select <strong>Generate AI Alt Text</strong></li>
             <li>When viewing a single asset's page, open the action menu and select <strong>Generate AI Alt Text</strong></li>
             <li>Upload a new asset (if the upload setting is enabled)</li>
@@ -20,57 +20,69 @@
     <li>The plugin will queue jobs to generate alt text for each selected asset</li>
 </ol>
 
-<hr />
 
-<h2>Bulk actions</h2>
-
-<p>Generate alt text for all assets, the <strong>Save translated results for each site</strong> setting will be ignored to perform the requested action.</p>
-
-<table class="data fullwidth">
-    <thead>
-        <tr>
-            <th>Site</th>
-            <th>Total Assets</th>
-            <th>With Alt Text</th>
-            <th>Without Alt Text</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr class="totalcount">
-            <td><strong>{% if sites|length > 1 %} All sites {% else %} {{ (sites|first).name }} {% endif %}</strong></td>
-            <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
-            <td>{{ totalAssetsWithAltTextForAllSites }}</td>
-            <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>
-            <td>
-                <div class="buttons">
-                    <a href="{{ actionUrl('ai-alt-text/generate/generate-all-assets') }}" class="btn small submit">Generate all</a>
-                    <a href="{{ actionUrl('ai-alt-text/generate/generate-assets-without-alt-text') }}" class="btn small submit">Generate missing</a>
-                </div>
-            </td>
-        </tr>
-        {% if sites|length > 1 %}
-            {% for site in sites %}
-            <tr>
-                <td>{{ site.name }}</td>
-                <td>{{ siteAltTextCounts[site.id].total }}</td>
-                <td>{{ siteAltTextCounts[site.id].with }}</td>
-                <td>{{ siteAltTextCounts[site.id].without }}</td>
-                <td>
-                    <div class="buttons">
-                        <a href="{{ actionUrl('ai-alt-text/generate/generate-all-assets', {siteId: site.id}) }}" class="btn small submit">Generate all</a>
-                        <a href="{{ actionUrl('ai-alt-text/generate/generate-assets-without-alt-text', {siteId: site.id}) }}" class="btn small submit">Generate missing</a>
-                    </div>
-                </td>
-            </tr>
-            {% endfor %}
-        {% endif %}
-    </tbody>
-</table>
-
-<hr />
 
 <h2 id="settings">Settings</h2>
+
+{{ forms.selectField({
+    label: "AI Provider"|t("aialttext"),
+    instructions: "Choose which AI service to use for generating alt text"|t("aialttext"),
+    id: "aiProvider",
+    name: "aiProvider",
+    options: [
+        { label: 'Anthropic Claude', value: 'anthropic' },
+        { label: 'OpenAI', value: 'openai' }
+    ],
+    value: settings.aiProvider,
+    errors: settings.getErrors("aiProvider"),
+    toggle: true,
+    targetPrefix: 'provider-'
+}) }}
+
+<div id="provider-anthropic" {% if settings.aiProvider != 'anthropic' %}class="hidden"{% endif %}>
+<h3>Anthropic Claude Settings</h3>
+
+{{ forms.autosuggestField({
+    label: "Anthropic API Key"|t("aialttext"),
+    instructions: "The API key from your [Anthropic Console account](https://console.anthropic.com/)"|t("aialttext"),
+    id: "anthropicApiKey",
+    name: "anthropicApiKey",
+    suggestEnvVars: true,
+    value: settings.anthropicApiKey,
+    errors: settings.getErrors("anthropicApiKey"),
+}) }}
+
+{{ forms.autosuggestField({
+    label: 'Anthropic Model'|t('aialttext'),
+    id: 'anthropicModel',
+    name: 'anthropicModel',
+    instructions: "The Anthropic Claude model to use. [See available models list](https://docs.anthropic.com/en/docs/about-claude/models). E.g., `claude-3-5-sonnet-latest`."|t("aialttext"),
+    value: settings.anthropicModel,
+    placeholder: 'claude-3-5-sonnet-latest',
+    errors: settings.getErrors('anthropicModel'),
+    suggestEnvVars: true,
+}) }}
+
+{{ forms.selectField({
+    label: 'Anthropic Image Input Detail Level'|t('app'),
+    id: 'anthropicImageDetailLevel',
+    name: 'anthropicImageDetailLevel',
+    instructions: "How large the image should be scaled before sending to Anthropic. Smaller images process faster and consume fewer tokens, but have less detail."|t("aialttext"),
+    options: [
+        { label: 'Very Low (200x200)', value: 'very_low' },
+        { label: 'Low (500x500)', value: 'low' },
+        { label: 'Medium (1000x1000)', value: 'medium' },
+        { label: 'High (1536x1536)', value: 'high' }
+    ],
+    value: settings.anthropicImageDetailLevel,
+    errors: settings.getErrors('anthropicImageDetailLevel')
+}) }}
+</div>
+
+
+
+<div id="provider-openai" {% if settings.aiProvider != 'openai' %}class="hidden"{% endif %}>
+<h3>OpenAI Settings</h3>
 
 {{ forms.autosuggestField({
     label: "OpenAI API Key"|t("aialttext"),
@@ -82,21 +94,11 @@
     errors: settings.getErrors("openAiApiKey"),
 }) }}
 
-{{ forms.textareaField({
-    label: 'Prompt'|t('app'),
-    id: 'prompt',
-    name: 'prompt',
-    instructions: "The text prompt which will be sent to OpenAI with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`"|t("aialttext"),
-    value: settings.prompt,
-    placeholder: "Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}",
-    errors: settings.getErrors('prompt'),
-}) }}
-
 {{ forms.autosuggestField({
     label: 'Open AI Model'|t('app'),
     id: 'openAiModel',
     name: 'openAiModel',
-    instructions: "The OpenAI model used to generate the response. To find out which models are capable of vision OpenAI suggest to look [on the models page](https://platform.openai.com/docs/models)"|t("aialttext"),
+    instructions: "The OpenAI model used to generate the response. To find out which models are capable of vision OpenAI suggest to look [on the models page](https://platform.openai.com/docs/models) E.g., `gpt-5-nano`."|t("aialttext"),
     value: settings.openAiModel,
     placeholder: 'gpt-5-nano',
     errors: settings.getErrors('openAiModel'),
@@ -107,15 +109,28 @@
     label: 'Open AI Image Input Detail Level'|t('app'),
     id: 'openAiImageInputDetailLevel',
     name: 'openAiImageInputDetailLevel',
-    instructions: "Specify the [Image input detail level](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#specify-image-input-detail-level), `low` costs the least at 85 tokens. Please read about [Image input requirements](https://platform.openai.com/docs/guides/images#image-input-requirements), [limitations](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#limitations) and [calculating costs & cost calculation examples](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#calculating-costs) in the OpenAI platform docs for more."|t("aialttext"),
+    instructions: "Specify the [Image input detail level](https://platform.openai.com/docs/guides/images?api-mode=responses&format=url#specify-image-input-detail-level), `low` costs the least at 85 tokens."|t("aialttext"),
     value: settings.openAiImageInputDetailLevel,
     placeholder: 'low',
     errors: settings.getErrors('openAiImageInputDetailLevel'),
     suggestEnvVars: true,
 }) }}
+</div>
+
+<hr />
+
+{{ forms.textareaField({
+    label: 'Prompt'|t('app'),
+    id: 'prompt',
+    name: 'prompt',
+    instructions: "The text prompt which will be sent to the AI with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`"|t("aialttext"),
+    value: settings.prompt,
+    placeholder: "Describe the image provided, make it suitable for an alt text description. Output in {site.language}",
+    errors: settings.getErrors('prompt'),
+}) }}
 
 {{ forms.lightswitchField({
-    label: 'propagate'|t('aialttext'),
+    label: 'Propagate'|t('aialttext'),
     id: 'propagate',
     name: ' ',
     instructions: "Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites."|t("aialttext"),
@@ -140,3 +155,16 @@
     on: settings.saveTranslatedResultsToEachSite,
     errors: settings.getErrors('saveTranslatedResultsToEachSite'),
 }) }}
+
+{% js %}
+window.addEventListener('pageshow', function (event) {
+    if (event.persisted) {
+        var providerSelect = document.querySelector('select[name="aiProvider"]');
+        if (providerSelect) {
+            providerSelect.dispatchEvent(new Event('change'));
+        }
+    }
+});
+{% endjs %}
+
+

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -41,7 +41,9 @@
     errors: settings.getErrors("aiProvider")
 }) }}
 
+
 <hr />
+
 
 <div id="settings-provider-anthropic">
     <h3>Anthropic Settings</h3>
@@ -119,7 +121,7 @@
         label: 'OpenAI Image Detail Level'|t('aialttext'),
         id: 'openAiImageInputDetailLevel',
         name: 'openAiImageInputDetailLevel',
-        instructions: "Controls the [detail level](https://developers.openai.com/api/docs/guides/images-vision#choose-an-image-detail-level) used when OpenAI is processing the image."|t("aialttext"),
+        instructions: "Controls the [detail level](https://developers.openai.com/api/docs/guides/images-vision#choose-an-image-detail-level) OpenAI uses to process the image. Large images are also pre-scaled to stay within API limits. `low` is fastest and cheapest."|t("aialttext"),
         options: [
             { label: 'Low - Fast, low-cost (512px x 512px)', value: 'low' },
             { label: 'High - Standard high-fidelity understanding', value: 'high' },

--- a/src/templates/_utility.twig
+++ b/src/templates/_utility.twig
@@ -1,0 +1,49 @@
+<div class="flex flex-nowrap" style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid rgba(0,0,0,0.05);">
+    <a href="{{ cpUrl('settings/plugins/ai-alt-text') }}" class="btn " data-icon="settings">Plugin Settings</a>
+</div>
+
+<h2>Bulk actions</h2>
+
+<p>Generate alt text for all assets, the <strong>Save translated results for each site</strong> setting will be ignored to perform the requested action.</p>
+
+<table class="data fullwidth">
+    <thead>
+        <tr>
+            <th>Site</th>
+            <th>Total Assets</th>
+            <th>With Alt Text</th>
+            <th>Without Alt Text</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="totalcount">
+            <td><strong>{% if sites|length > 1 %} All sites {% else %} {{ (sites|first).name }} {% endif %}</strong></td>
+            <td>{{ totalAssetsWithAltTextForAllSites + totalAssetsWithoutAltTextForAllSites }}</td>
+            <td>{{ totalAssetsWithAltTextForAllSites }}</td>
+            <td>{{ totalAssetsWithoutAltTextForAllSites }}</td>
+            <td>
+                <div class="buttons">
+                    <a href="{{ actionUrl('ai-alt-text/generate/generate-all-assets') }}" class="btn small submit">Generate all</a>
+                    <a href="{{ actionUrl('ai-alt-text/generate/generate-assets-without-alt-text') }}" class="btn small submit">Generate missing</a>
+                </div>
+            </td>
+        </tr>
+        {% if sites|length > 1 %}
+            {% for site in sites %}
+            <tr>
+                <td>{{ site.name }}</td>
+                <td>{{ siteAltTextCounts[site.id].total }}</td>
+                <td>{{ siteAltTextCounts[site.id].with }}</td>
+                <td>{{ siteAltTextCounts[site.id].without }}</td>
+                <td>
+                    <div class="buttons">
+                        <a href="{{ actionUrl('ai-alt-text/generate/generate-all-assets', {siteId: site.id}) }}" class="btn small submit">Generate all</a>
+                        <a href="{{ actionUrl('ai-alt-text/generate/generate-assets-without-alt-text', {siteId: site.id}) }}" class="btn small submit">Generate missing</a>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        {% endif %}
+    </tbody>
+</table>

--- a/src/utilities/AiAltTextUtility.php
+++ b/src/utilities/AiAltTextUtility.php
@@ -65,8 +65,7 @@ class AiAltTextUtility extends Utility
                     ->kind(Asset::KIND_IMAGE)
                     ->siteId($site->id)
                     ->status(null)
-                    ->where(['not', ['alt' => null]])
-                    ->andWhere(['not', ['alt' => '']])
+                    ->hasAlt(true)
                     ->count();
                 
                 $withoutAltCount = $totalImageAssets - $withAltCount;

--- a/src/utilities/AiAltTextUtility.php
+++ b/src/utilities/AiAltTextUtility.php
@@ -4,7 +4,6 @@ namespace heavymetalavo\craftaialttext\utilities;
 use Craft;
 use craft\base\Utility;
 use craft\elements\Asset;
-use heavymetalavo\craftaialttext\AiAltText;
 
 /**
  * AI Alt Text Bulk Actions Utility

--- a/src/utilities/AiAltTextUtility.php
+++ b/src/utilities/AiAltTextUtility.php
@@ -1,0 +1,97 @@
+<?php
+namespace heavymetalavo\craftaialttext\utilities;
+
+use Craft;
+use craft\base\Utility;
+use craft\elements\Asset;
+use heavymetalavo\craftaialttext\AiAltText;
+
+/**
+ * AI Alt Text Bulk Actions Utility
+ */
+class AiAltTextUtility extends Utility
+{
+    /**
+     * @inheritdoc
+     */
+    public static function displayName(): string
+    {
+        return Craft::t('ai-alt-text', 'AI Alt Text');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function id(): string
+    {
+        return 'ai-alt-text-bulk-actions';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function iconPath(): ?string
+    {
+        return Craft::getAlias('@heavymetalavo/craftaialttext/icon.svg');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function contentHtml(): string
+    {
+        $currentSite = Craft::$app->getSites()->getCurrentSite();
+        $sites = Craft::$app->getSites()->getAllSites();
+        
+        $totalAssetsWithAltTextForAllSites = 0;
+        $totalAssetsWithoutAltTextForAllSites = 0;
+        $siteAltTextCounts = [];
+        
+        foreach ($sites as $site) {
+            $siteAltTextCounts[$site->id] = [
+                'total' => 0,
+                'with' => 0,
+                'without' => 0
+            ];
+
+            try {
+                $totalImageAssets = Asset::find()
+                    ->kind(Asset::KIND_IMAGE)
+                    ->siteId($site->id)
+                    ->status(null)
+                    ->count();
+                
+                $withAltCount = Asset::find()
+                    ->kind(Asset::KIND_IMAGE)
+                    ->siteId($site->id)
+                    ->status(null)
+                    ->where(['not', ['alt' => null]])
+                    ->andWhere(['not', ['alt' => '']])
+                    ->count();
+                
+                $withoutAltCount = $totalImageAssets - $withAltCount;
+                
+                $siteAltTextCounts[$site->id] = [
+                    'total' => $totalImageAssets,
+                    'with' => $withAltCount,
+                    'without' => $withoutAltCount
+                ];
+                
+                $totalAssetsWithAltTextForAllSites += $withAltCount;
+                $totalAssetsWithoutAltTextForAllSites += $withoutAltCount;
+            } catch (\Exception $e) {
+                Craft::error("Error counting assets for site {$site->name}: " . $e->getMessage(), __METHOD__);
+            }
+        }
+        
+        return Craft::$app->getView()->renderTemplate(
+            'ai-alt-text/_utility',
+            [
+                'totalAssetsWithAltTextForAllSites' => $totalAssetsWithAltTextForAllSites,
+                'totalAssetsWithoutAltTextForAllSites' => $totalAssetsWithoutAltTextForAllSites,
+                'sites' => $sites,
+                'siteAltTextCounts' => $siteAltTextCounts,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Changelog

- Adding functionality to support a new AI Provider (Anthropic)
- Adding new setting field to choose AI Provider (OpenAI or Anthropic)
- Adding automatic image scaling for Anthropic to account for 5MB payload limits and pixel area token costs
- Adding automatic image scaling for OpenAI to account for 20MB payload limits and patch budget constraints
- Added support for new OpenAI detail levels `original` & `auto` option for OpenAI (gpt-5.4+ models)
- Updated bulk actions table and buttons to be migrated to the CraftCMS Dashboard utilities area for improved performance and visibility
- Updated shared logic for image transformation and base64 encoding across providers
- Updated error handling for API request failures and asset accessibility checks
- Updated settings page setup instructions & field instructions and placeholders to be more clear
- Updated all use declartions to be grouped if possible
- Updated plugin services to be registered as plugin components so we can access via the plugin instance rather than via instantiating each time we require them.
- Updated all request/response model class property casing to use camelcase instead of snake case
- Updated request models to no longer use a method to progressively build the payload on each setter
- Updated default prompt in readme and settings to be more concise and direct for intended purpose, to not assuming gender, and to avoid random prefixes.
- Updated `generateForNewAssets` setting to be true by default
- Fixed bug where alt text would propagate across sites despite propagate setting being disabled
- Fixed TypeError in OpenAI error handling where a non-array error response would crash `parseResponse()`