### PR TITLE
Hotfix/anthropic large local images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for AI Alt Text
 
-## 1.7.1 - 2026-03-24
+## 1.7.1 - 2026-03-25
 
 - Adding a fallback for OpenAI and Anthropic when the image URL is reachable from Craft but unreachable from the provider: a fallback attempt sends the image as base64 instead for round 2 🥊
 - Fixing issue for local volumes where image urls could be sent to AI providers as relative URLs, now converts to absolute site URLs before making a request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.7.1 - 2026-03-24
 
 - Adding a fallback for OpenAI and Anthropic when the image URL is reachable from Craft but unreachable from the provider: a fallback attempt sends the image as base64 instead for round 2 🥊
-- Fixing issue for local volumes where image urls could be send as root-relative URLs, now converts to absolute site URLs before sending to AI Providers
+- Fixing issue for local volumes where image urls could be sent to AI providers as relative URLs, now converts to absolute site URLs before making a request.
 - Updating the OpenAI vision `maxFileSizeMb` threshold from 20MB to 512MB to align with new API limit.
 - Updating HTTP client timeouts to 30 seconds to support processing larger images.
 - Replacing inline fully qualified class names with `use` declarations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes for AI Alt Text
 
+## 1.7.1 - 2026-03-24
+
+- Adding a fallback for OpenAI and Anthropic when the image URL is reachable from Craft but unreachable from the provider: a fallback attempt sends the image as base64 instead for round 2 🥊
+- Fixing issue for local volumes where image urls could be send as root-relative URLs, now converts to absolute site URLs before sending to AI Providers
+- Updating the OpenAI vision `maxFileSizeMb` threshold from 20MB to 512MB to align with new API limit.
+- Updating HTTP client timeouts to 30 seconds to support processing larger images.
+- Replacing inline fully qualified class names with `use` declarations
+
 ## 1.7.0 - 2026-03-19
 
 - Adding functionality to support a new AI Provider (Anthropic)

--- a/src/console/controllers/GenerateController.php
+++ b/src/console/controllers/GenerateController.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\console\Controller;
 use craft\elements\Asset;
 use craft\helpers\Console;
+use Exception;
 use heavymetalavo\craftaialttext\AiAltText;
 use yii\console\ExitCode;
 use yii\helpers\BaseConsole;
@@ -98,7 +99,7 @@ class GenerateController extends Controller
             
             return ExitCode::OK;
             
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->failure("Error queueing alt text generation: {$e->getMessage()}");
             return ExitCode::SOFTWARE;
         }
@@ -367,7 +368,7 @@ class GenerateController extends Controller
                             // Free memory
                             unset($asset);
                             
-                        } catch (\Exception $e) {
+                        } catch (Exception $e) {
                             $this->failure("Error processing asset {$assetId}: {$e->getMessage()}");
                         }
                         
@@ -399,7 +400,7 @@ class GenerateController extends Controller
             
             return ExitCode::OK;
             
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Console::endProgress();
             $this->failure("\nError: {$e->getMessage()}");
             return ExitCode::SOFTWARE;

--- a/src/controllers/GenerateController.php
+++ b/src/controllers/GenerateController.php
@@ -5,6 +5,7 @@ namespace heavymetalavo\craftaialttext\controllers;
 use Craft;
 use craft\elements\Asset;
 use craft\web\Controller;
+use Exception;
 use heavymetalavo\craftaialttext\AiAltText;
 use yii\web\Response;
 
@@ -51,7 +52,7 @@ class GenerateController extends Controller
                 'success' => true,
                 'message' => Craft::t('ai-alt-text', 'Alt text generation has been queued'),
             ]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Craft::error('Error queueing alt text generation: ' . $e->getMessage(), __METHOD__);
 
             return $this->asJson([
@@ -152,7 +153,7 @@ class GenerateController extends Controller
                             // Create a job for the asset
                             $plugin->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
-                        } catch (\Exception $e) {
+                        } catch (Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);
                         }
                     }
@@ -186,7 +187,7 @@ class GenerateController extends Controller
             
             // Redirect back to settings page
             return $this->redirect('utilities/ai-alt-text-bulk-actions');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Craft::error('Error queueing alt text generation for assets without alt text: ' . $e->getMessage(), __METHOD__);
             
             Craft::$app->getSession()->setError(
@@ -280,7 +281,7 @@ class GenerateController extends Controller
                             // Set force regeneration to true to regenerate all assets
                             $plugin->aiAltTextService->createJob($asset, false, $site->id, false, true, true);
                             $queuedCount++;
-                        } catch (\Exception $e) {
+                        } catch (Exception $e) {
                             Craft::error('Error queuing job for asset ' . $asset->id . ': ' . $e->getMessage(), __METHOD__);
                         }
                     }
@@ -314,7 +315,7 @@ class GenerateController extends Controller
             
             // Redirect back to settings page
             return $this->redirect('utilities/ai-alt-text-bulk-actions');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Craft::error('Error queueing alt text generation for all assets: ' . $e->getMessage(), __METHOD__);
             
             Craft::$app->getSession()->setError(

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -21,6 +21,7 @@ class AnthropicService extends ApiService
     private string $model;
     private string $detailLevel;
     private string $baseUrl = 'https://api.anthropic.com/v1/messages';
+    private bool $hasFallbackRan = false;
 
     public function __construct()
     {
@@ -61,11 +62,14 @@ class AnthropicService extends ApiService
         
         $imageUrl = $asset->getUrl($transformParams, true);
 
-        // If we have a URL, check if it's accessible remotely
+        // If we have a URL, check if it's accessible remotely (resolve root-relative URLs to the site base; leave absolute URLs as-is)
         if (!empty($imageUrl)) {
-            if (!$this->isUrlAccessible($imageUrl)) {
+            $resolvedUrl = $this->resolveAssetUrl($asset, $imageUrl);
+            if (!$this->isUrlAccessible($resolvedUrl)) {
                 Craft::warning('Asset URL is not accessible remotely: ' . $imageUrl, __METHOD__);
                 $imageUrl = null; // Reset to null to trigger base64 encoding
+            } else {
+                $imageUrl = $resolvedUrl;
             }
         }
 
@@ -89,7 +93,7 @@ class AnthropicService extends ApiService
     {
         try {
             // Log the request intent for debugging
-            Craft::info('Anthropic API request initiated for asset: ' . $asset->filename, __METHOD__);
+            Craft::info('Anthropic API request initiated for asset: ' . $asset->filename . ' with image URL: ' . $imageUrl, __METHOD__);
 
             $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
 
@@ -141,9 +145,19 @@ class AnthropicService extends ApiService
             
             $responseModel = new AnthropicResponse();
             if ($responseModel->parseResponse($errorResponse) && $responseModel->hasError()) {
-                throw new Exception("Anthropic API request failed: " . $responseModel->getErrorMessage());
+                throw new Exception("Anthropic API request failed pares response: " . $responseModel->getErrorMessage());
             }
-            throw new Exception("Anthropic API request failed: " . $errorResponse);
+
+            // Try a fallback where if we have accessed the image before but the provider cannot access it, we can try again with the base64 encoded contents
+            $decodedErrorResponse = Json::decode($errorResponse);
+            if ($decodedErrorResponse['error']['type'] === 'invalid_request_error' && !$this->hasFallbackRan && !$base64ImageSource) {
+                $this->hasFallbackRan = true;
+                Craft::warning('Can access the asset URL, but the provider could not, forcing base64 fallback', __METHOD__);
+                $asset->getVolume()->getFs()->hasUrls = false;
+                return $this->generateAltText($asset, $siteId);
+            }
+
+            throw new Exception("Anthropic API request failed error response: " . $errorResponse);
         }
     }
 }

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -7,6 +7,7 @@ use craft\base\Component;
 use craft\elements\Asset;
 use craft\helpers\{App, Json};
 use Exception;
+use GuzzleHttp\Exception\RequestException;
 use heavymetalavo\craftaialttext\AiAltText;
 use heavymetalavo\craftaialttext\models\api\{AnthropicRequest, AnthropicResponse};
 
@@ -139,7 +140,7 @@ class AnthropicService extends ApiService
             }
 
             return $responseModel->getText();
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             $errorResponse = $e->hasResponse() ? (string)$e->getResponse()->getBody() : $e->getMessage();
             Craft::error("Anthropic API Error: " . $errorResponse, __METHOD__);
             

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -65,26 +65,25 @@ class AnthropicService extends ApiService
 
         // If we have a URL, check if it's accessible remotely (resolve root-relative URLs to the site base; leave absolute URLs as-is)
         if (!empty($imageUrl)) {
-            $resolvedUrl = $this->resolveAssetUrl($asset, $imageUrl);
-            if (!$this->isUrlAccessible($resolvedUrl)) {
-                Craft::warning('Asset URL is not accessible remotely: ' . $imageUrl, __METHOD__);
-                $imageUrl = null; // Reset to null to trigger base64 encoding
-            } else {
-                $imageUrl = $resolvedUrl;
+            $imageUrl = $this->resolveAssetUrl($asset, $imageUrl);
+            
+            if (!$this->forceBase64 && !$this->isUrlAccessible($imageUrl)) {
+                Craft::warning('Asset URL is not accessible locally: ' . $imageUrl, __METHOD__);
+                $this->forceBase64 = true;
             }
         }
 
         $imageSource = null;
 
-        // If no public URL is available or URL is not accessible, fall back to base64 encoding
-        if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
+        // If no public URL is available, or URL is not accessible locally, or base64 is forced
+        if ($this->forceBase64 || empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
             $base64Image = $this->getAssetBase64String($asset, $imageUrl, $transformParams);
             $imageSource = [
                 'type' => 'base64',
                 'media_type' => $transformMimeType,
                 'data' => $base64Image,
             ];
-            $imageUrl = null;
+            $imageUrl = null; // Clear URL so it's not sent in the payload
         }
 
         return $this->sendRequest($imageUrl, $imageSource, $transformMimeType, $asset, $siteId);
@@ -153,8 +152,8 @@ class AnthropicService extends ApiService
             $decodedErrorResponse = Json::decode($errorResponse);
             if ($decodedErrorResponse['error']['type'] === 'invalid_request_error' && !$this->hasFallbackRan && !$base64ImageSource) {
                 $this->hasFallbackRan = true;
+                $this->forceBase64 = true;
                 Craft::warning('Can access the asset URL, but the provider could not, forcing base64 fallback', __METHOD__);
-                $asset->getVolume()->getFs()->hasUrls = false;
                 return $this->generateAltText($asset, $siteId);
             }
 

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -145,7 +145,7 @@ class AnthropicService extends ApiService
             
             $responseModel = new AnthropicResponse();
             if ($responseModel->parseResponse($errorResponse) && $responseModel->hasError()) {
-                throw new Exception("Anthropic API request failed pares response: " . $responseModel->getErrorMessage());
+                throw new Exception("Anthropic API request failed parsed response: " . $responseModel->getErrorMessage());
             }
 
             // Try a fallback where if we have accessed the image before but the provider cannot access it, we can try again with the base64 encoded contents

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -33,6 +33,11 @@ abstract class ApiService extends Component
      */
     protected Client $client;
 
+    /**
+     * @var bool Forces the use of base64 encoding even if the asset has a URL (useful for fallback when provider fails to download from URL)
+     */
+    protected bool $forceBase64 = false;
+
     public function __construct($config = [])
     {
         parent::__construct($config);
@@ -48,11 +53,15 @@ abstract class ApiService extends Component
      */
     protected function resolveAssetUrl(Asset $asset, string $url): string
     {
-        if (UrlHelper::isRootRelativeUrl($url)) {
-            return UrlHelper::siteUrl($url, null, null, $asset->siteId);
-        }
+        // Convert `//bucket.s3.com/img.jpg` to `https://bucket.s3.com/img.jpg`
         if (UrlHelper::isProtocolRelativeUrl($url)) {
             return UrlHelper::urlWithScheme($url, 'https');
+        }
+
+        // Catch both root-relative (`/imgs/file.jpg`) and normal relative (`imgs/file.jpg`) local volume paths
+        // and convert them to absolute URLs via the Craft Site URL. (`domain.com/imgs/file.jpg`)
+        if (!UrlHelper::isAbsoluteUrl($url)) {
+            return UrlHelper::siteUrl($url, null, null, $asset->siteId);
         }
 
         return $url;

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -36,7 +36,7 @@ abstract class ApiService extends Component
     public function __construct($config = [])
     {
         parent::__construct($config);
-        $this->client = Craft::createGuzzleClient(['timeout' => 10]);
+        $this->client = Craft::createGuzzleClient(['timeout' => 30]);
     }
     /**
      * Required implementation for child services to generate their specific payloads.
@@ -68,8 +68,8 @@ abstract class ApiService extends Component
     {
         try {
             $response = $this->client->head($url, [
-                'timeout' => 5,
-                'connect_timeout' => 5,
+                'timeout' => 30,
+                'connect_timeout' => 30,
                 'allow_redirects' => true,
             ]);
             return $response->getStatusCode() === 200;

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -5,6 +5,7 @@ namespace heavymetalavo\craftaialttext\services;
 use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
+use craft\helpers\UrlHelper;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
@@ -43,9 +44,24 @@ abstract class ApiService extends Component
     abstract public function generateAltText(Asset $asset, ?int $siteId = null): string;
 
     /**
+     * Turns root-relative asset URLs into absolute URLs for Guzzle and provider APIs; leaves absolute URLs unchanged.
+     */
+    protected function resolveAssetUrl(Asset $asset, string $url): string
+    {
+        if (UrlHelper::isRootRelativeUrl($url)) {
+            return UrlHelper::siteUrl($url, null, null, $asset->siteId);
+        }
+        if (UrlHelper::isProtocolRelativeUrl($url)) {
+            return UrlHelper::urlWithScheme($url, 'https');
+        }
+
+        return $url;
+    }
+
+    /**
      * Checks if a URL is accessible remotely.
      *
-     * @param string $url The URL to check
+     * @param string $url The URL to check (already resolved for HTTP if needed)
      * @return bool Whether the URL is accessible
      */
     protected function isUrlAccessible(string $url): bool
@@ -133,6 +149,7 @@ abstract class ApiService extends Component
     {
         // Always try to fetch the transformed or public URL using Guzzle to get the resized contents
         if (!empty($imageUrl)) {
+            $imageUrl = $this->resolveAssetUrl($asset, $imageUrl);
             try {
                 $response = $this->client->get($imageUrl);
                 if ($response->getStatusCode() === 200) {
@@ -143,9 +160,9 @@ abstract class ApiService extends Component
                 Craft::warning('Failed to download image URL for Base64 conversion: ' . $e->getMessage(), __METHOD__);
             }
         }
-
+        
         if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
-            
+            Craft::warning('No image URL or asset contents found, falling back to original asset contents', __METHOD__);
             if ($this->needsFormatConversion($asset)) {
                 $assetMimeType = strtolower($asset->getMimeType());
                 // See https://github.com/craftcms/cms/issues/17238#issuecomment-2873206148

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -167,11 +167,14 @@ class OpenAiService extends ApiService
         // Make sure that we do not get a "generate transform" url, but a real url with true
         $imageUrl = $asset->getUrl($transformParams, true);
 
-        // If we have a URL, check if it's accessible remotely
+        // If we have a URL, check if it's accessible remotely (resolve root-relative URLs to the site base; leave absolute URLs as-is)
         if (!empty($imageUrl)) {
-            if (!$this->isUrlAccessible($imageUrl)) {
+            $resolvedUrl = $this->resolveAssetUrl($asset, $imageUrl);
+            if (!$this->isUrlAccessible($resolvedUrl)) {
                 Craft::warning('Asset URL is not accessible remotely: ' . $imageUrl, __METHOD__);
                 $imageUrl = null; // Reset to null to trigger base64 encoding
+            } else {
+                $imageUrl = $resolvedUrl;
             }
         }
 

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -170,19 +170,18 @@ class OpenAiService extends ApiService
 
         // If we have a URL, check if it's accessible remotely (resolve root-relative URLs to the site base; leave absolute URLs as-is)
         if (!empty($imageUrl)) {
-            $resolvedUrl = $this->resolveAssetUrl($asset, $imageUrl);
-            if (!$this->isUrlAccessible($resolvedUrl)) {
-                Craft::warning('Asset URL is not accessible remotely: ' . $imageUrl, __METHOD__);
-                $imageUrl = null; // Reset to null to trigger base64 encoding
-            } else {
-                $imageUrl = $resolvedUrl;
+            $imageUrl = $this->resolveAssetUrl($asset, $imageUrl);
+            
+            if (!$this->forceBase64 && !$this->isUrlAccessible($imageUrl)) {
+                Craft::warning('Asset URL is not accessible locally: ' . $imageUrl, __METHOD__);
+                $this->forceBase64 = true;
             }
         }
 
-        // If no public URL is available or URL is not accessible, try to get the file contents and encode as base64
-        if (empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
+        // If no public URL is available, or URL is not accessible locally, or base64 is forced
+        if ($this->forceBase64 || empty($imageUrl) || !$asset->getVolume()->getFs()->hasUrls) {
             $base64Image = $this->getAssetBase64String($asset, $imageUrl, $transformParams);
-            $imageUrl = "data:$transformMimeType;base64,$base64Image";
+            $imageUrl = "data:$transformMimeType;base64,$base64Image"; // Replace URL with data string
         }
 
         // Only set detail parameter for images larger than 512x512 pixels
@@ -242,8 +241,8 @@ class OpenAiService extends ApiService
 
             if ($errorDetails && isset($errorDetails['type']) && $errorDetails['type'] === 'invalid_request_error' && !$this->hasFallbackRan && !$isBase64) {
                 $this->hasFallbackRan = true;
+                $this->forceBase64 = true;
                 Craft::warning('Can access the asset URL, but the provider could not, forcing base64 fallback', __METHOD__);
-                $asset->getVolume()->getFs()->hasUrls = false;
                 return $this->generateAltText($asset, $siteId);
             }
 

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -28,6 +28,7 @@ class OpenAiService extends ApiService
     private string $apiKey;
     private string $model;
     private string $baseUrl = 'https://api.openai.com/v1';
+    private bool $hasFallbackRan = false;
 
     /**
      * Constructor
@@ -109,7 +110,7 @@ class OpenAiService extends ApiService
                     $errorMsg = 'OpenAI API error: ' . $errorData['error']['message'];
                     Craft::error('OpenAI API error: ' . $responseBody, __METHOD__);
 
-                    $errorResponse->setError($errorMsg);
+                    $errorResponse->setError($errorMsg, $errorData['error']);
                     return $errorResponse;
                 }
             }
@@ -149,9 +150,9 @@ class OpenAiService extends ApiService
         // Validate image support using the parent base service method
         $this->validateImageSupport($asset);
 
-        // OpenAI Vision: max 2048px long edge (API handles short edge scaling internally), max 20MB payload
+        // OpenAI Vision: max 2048px long edge (API handles short edge scaling internally), max 512MB payload, max 1536 patches
         // Patch budget based on detail:high tiling — each 512px tile costs 170 tokens + 85 base
-        $transformParams = $this->getVisionTransformParams($asset, maxLongEdge: 2048, maxFileSizeMb: 20, maxPatches: 1536);
+        $transformParams = $this->getVisionTransformParams($asset, maxLongEdge: 2048, maxFileSizeMb: 512, maxPatches: 1536);
 
         if (!empty($transformParams)) {
             $asset->setTransform($transformParams);
@@ -236,6 +237,16 @@ class OpenAiService extends ApiService
 
         // Check for errors from the API
         if ($response->hasError()) {
+            $errorDetails = $response->error['details'] ?? null;
+            $isBase64 = strpos($imageUrl, 'data:') === 0;
+
+            if ($errorDetails && isset($errorDetails['type']) && $errorDetails['type'] === 'invalid_request_error' && !$this->hasFallbackRan && !$isBase64) {
+                $this->hasFallbackRan = true;
+                Craft::warning('Can access the asset URL, but the provider could not, forcing base64 fallback', __METHOD__);
+                $asset->getVolume()->getFs()->hasUrls = false;
+                return $this->generateAltText($asset, $siteId);
+            }
+
             throw new Exception($response->getErrorMessage());
         }
 

--- a/src/utilities/AiAltTextUtility.php
+++ b/src/utilities/AiAltTextUtility.php
@@ -4,6 +4,7 @@ namespace heavymetalavo\craftaialttext\utilities;
 use Craft;
 use craft\base\Utility;
 use craft\elements\Asset;
+use Exception;
 
 /**
  * AI Alt Text Bulk Actions Utility
@@ -77,7 +78,7 @@ class AiAltTextUtility extends Utility
                 
                 $totalAssetsWithAltTextForAllSites += $withAltCount;
                 $totalAssetsWithoutAltTextForAllSites += $withoutAltCount;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 Craft::error("Error counting assets for site {$site->name}: " . $e->getMessage(), __METHOD__);
             }
         }


### PR DESCRIPTION
## Changes

- Adding a fallback for OpenAI and Anthropic when the image URL is reachable from Craft but unreachable from the provider: a fallback attempt sends the image as base64 instead for round 2 🥊
- Fixing issue for local volumes where image urls could be sent to AI providers as relative URLs, now converts to absolute site URLs before making a request.
- Updating the OpenAI vision `maxFileSizeMb` threshold from 20MB to 512MB to align with new API limit.
- Updating HTTP client timeouts to 30 seconds to support processing larger images.
- Replacing inline fully qualified class names with `use` declarations
