### PR TITLE
feature/process-svgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for AI Alt Text
 
+## UNRELEASED
+
+- Added a new `processSvgs` setting which now serves as the primary control for whether SVG assets are processed by the plugin. This logic is now decoupled from Craft's global `transformSvgs` setting.
+- Updated error handling to gracefully skip SVGs when `processSvgs` is `false` and complete queue jobs successfully instead of throwing exceptions.
+
 ## 1.7.1 - 2026-03-25
 
 - Adding a fallback for OpenAI and Anthropic when the image URL is reachable from Craft but unreachable from the provider: a fallback attempt sends the image as base64 instead for round 2 🥊

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -108,10 +108,14 @@ class AiAltText extends Plugin
                 $asset = $event->sender;
 
                 // Only process new assets that are images and if the setting is enabled
+                $isSvg = strtolower($asset->getMimeType()) === 'image/svg+xml';
+                $processSvgs = $this->getSettings()->processSvgs;
+
                 if (
                     $event->isNew
                     && $asset->kind === Asset::KIND_IMAGE
                     && $this->getSettings()->generateForNewAssets
+                    && (!$isSvg || $processSvgs)
                 ) {
                     // Save current site ID
                     $currentSite = Cp::requestedSite();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -87,6 +87,11 @@ class Settings extends Model
     public bool $generateForNewAssets = true;
 
     /**
+     * @var bool Whether to attempt generating alt text for SVG files
+     */
+    public bool $processSvgs = false;
+
+    /**
      * @inheritdoc
      */
     public function defineRules(): array
@@ -130,6 +135,7 @@ class Settings extends Model
             ['propagate', 'boolean'],
             ['saveTranslatedResultsToEachSite', 'boolean'],
             ['generateForNewAssets', 'boolean'],
+            ['processSvgs', 'boolean'],
         ];
     }
 }

--- a/src/services/AiAltTextService.php
+++ b/src/services/AiAltTextService.php
@@ -23,12 +23,13 @@ class AiAltTextService extends Component
 
     /**
      * Creates a job for the given element
-     * 
+     *
      * @param Asset $asset The asset to create a job for
      * @param bool $saveCurrentSiteOffQueue Whether to process the current site off queue
      * @param int|null $currentSiteId The current site ID
      * @param bool $skipExistingJobCheck Whether to skip the check for existing jobs (useful for bulk operations)
      * @param bool $forceRegeneration Whether to force regeneration even if alt text exists
+     * @throws Exception
      */
     public function createJob(Asset $asset, $saveCurrentSiteOffQueue = false, $currentSiteId = null, $skipExistingJobCheck = false, $forceRegeneration = false, $skipSaveTranslatedResultsToEachSiteSetting = false): void
     {

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -35,10 +35,13 @@ class AnthropicService extends ApiService
 
     /**
      * Generates alt text using the Anthropic Messages API
+     * @throws Exception
      */
     public function generateAltText(Asset $asset, ?int $siteId = null): string
     {
-        $this->validateImageSupport($asset);
+        if (!$this->validateImageSupport($asset)) {
+            return '';
+        }
 
         $targetDimension = match ($this->detailLevel) {
             'low' => 500,
@@ -89,6 +92,9 @@ class AnthropicService extends ApiService
         return $this->sendRequest($imageUrl, $imageSource, $transformMimeType, $asset, $siteId);
     }
 
+    /**
+     * @throws Exception
+     */
     private function sendRequest(?string $imageUrl, ?array $base64ImageSource, string $mimeType, Asset $asset, ?int $siteId): string
     {
         try {

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -9,6 +9,7 @@ use craft\helpers\UrlHelper;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use heavymetalavo\craftaialttext\AiAltText;
 
 /**
  * Base API Service
@@ -95,15 +96,27 @@ abstract class ApiService extends Component
      * @param bool $allowSvgs Whether the endpoint natively supports SVGs or relies on Craft's SVG transform pipeline
      * @throws Exception If the asset format is invalid or fundamentally unsupported
      */
-    protected function validateImageSupport(Asset $asset, bool $allowSvgs = false): void
+    protected function validateImageSupport(Asset $asset, bool $allowSvgs = false): bool
     {
         $mimeType = strtolower($asset->getMimeType());
 
         if ($mimeType === 'image/svg+xml') {
-            if (!$allowSvgs && !Craft::$app->getConfig()->getGeneral()->transformSvgs) {
-                throw new Exception("SVGs are not natively supported by this API provider and Craft's `transformSvgs` explicitly disables fallback rasterization.");
+            if (!AiAltText::getInstance()->getSettings()->processSvgs) {
+                Craft::info("Skipping SVG asset (processSvgs disabled): $asset->filename", __METHOD__);
+                return false;
+            }
+
+            if (!$allowSvgs) {
+                if (!Craft::$app->getConfig()->getGeneral()->transformSvgs) {
+                    Craft::warning("SVG asset $asset->filename requires transformSvgs to be enabled in Craft general config to be processed; skipping.", __METHOD__);
+                    return false;
+                }
+                
+                Craft::debug("SVG asset $asset->filename is not natively supported by the provider, will attempt transformation.", __METHOD__);
             }
         }
+        
+        return true;
     }
 
     /**

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -148,7 +148,9 @@ class OpenAiService extends ApiService
     {
         $plugin = AiAltText::getInstance();
         // Validate image support using the parent base service method
-        $this->validateImageSupport($asset);
+        if (!$this->validateImageSupport($asset)) {
+            return '';
+        }
 
         // OpenAI Vision: max 2048px long edge (API handles short edge scaling internally), max 512MB payload, max 1536 patches
         // Patch budget based on detail:high tiling — each 512px tile costs 170 tokens + 85 base

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -167,6 +167,15 @@
 }) }}
 
 {{ forms.lightswitchField({
+    label: 'Process SVGs'|t('aialttext'),
+    id: 'processSvgs',
+    name: 'processSvgs',
+    instructions: "Attempt to generate alt text for SVG files when they are uploaded or batched processed. This requires Craft's global `transformSvgs` setting to be enabled."|t("aialttext"),
+    on: settings.processSvgs,
+    errors: settings.getErrors('processSvgs'),
+}) }}
+
+{{ forms.lightswitchField({
     label: 'Save translated results for each site'|t('aialttext'),
     id: 'saveTranslatedResultsToEachSite',
     name: 'saveTranslatedResultsToEachSite',


### PR DESCRIPTION
- Added a new `processSvgs` setting which now serves as the primary control for whether SVG assets are processed by the plugin. This logic is now decoupled from Craft's global `transformSvgs` setting.
- Updated error handling to gracefully skip SVGs when `processSvgs` is `false` and complete queue jobs successfully instead of throwing exceptions.

Should address this issue https://github.com/heavymetalavo/craft-aialttext/issues/24