### PR TITLE
feat: send prompt as system/instruction message and add {site.languageName} variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@
 /node_modules
 /vendor
 Agents.md
+CLAUDE.md
+.claude/
 .cursor/
+.cursorignore
+temp.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release Notes for AI Alt Text
 
+## Unreleased
+> {note} If you customised the **prompt** setting, it is left untouched — update it manually to adopt the `{site.languageName}` variable which can offer better results for non-english language sites. Installs still using any former default prompt are migrated automatically.
+
+- Changed the default prompt to output the language as `{site.languageName} ({site.language})` (e.g. `English (United Kingdom) (en-GB)`), making the language fully visible and editable. Existing installs whose stored prompt matches any former default prompt are automatically migrated to the new one; any customised prompt is left untouched.
+- Added a `{site.languageName}` prompt token that resolves to the language's display name only.
+- The prompt is now sent as the system/instruction message for both providers — Anthropic via `system`, and OpenAI via the Responses API top-level `instructions` parameter. The user turn now carries only the image and the shared generation trigger.
+- Fixed a bug where saving a setting from a migration could replace all other stored plugin settings (API keys, provider, model, etc.) in project config. Both the new prompt migration and the existing AI provider migration now merge the single changed setting into the stored settings instead, and skip safely (with a warning) on environments where `allowAdminChanges` is disabled instead of failing the update.
+- Bumped the plugin schema version so pending migrations are actually detected and run by Craft's updater.
+- Fixed a bug where root-relative asset/transform URLs (e.g. from a site with a path-only base URL like `/en`, or during console/queue requests) were sent unresolved to the AI provider and the base64 fallback, causing both to fail. They are now resolved against the primary site's host.
+- Fixed alt text generation throwing an error when no site ID is provided; it now falls back to the asset's own site.
+- Corrected a misleading warning message that reported a supported MIME type as unsupported when falling back to source file contents for base64 encoding.
+
 ## 1.9.1 - 2026-06-09
 - Removed the plugin-level preflight check before sending a request with an image URL to an AI provider. A CDN (e.g. TwicPics) could reject the preflight request from the plugin despite the file being publicly available and accepted by an AI provider.
 - Updated base64 fallback behavior so original asset file contents are only sent when their MIME type is accepted by the AI provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Release Notes for AI Alt Text
 
 ## 1.10.0 - 2026-07-07
-> {note} If you customised the **prompt** setting, it is left untouched — update it manually to adopt the `{site.languageName}` variable which can offer better results for non-english language sites. Installs still using any former default prompt are migrated automatically.
 
-- Changed the default prompt to output the language as `{site.languageName} (BCP 47: {site.language})` (e.g. `English (United Kingdom) (BCP 47: en-GB)`), making the language fully visible and editable. Existing installs whose stored prompt matches any former default prompt are automatically migrated to the new one; any customised prompt is left untouched.
+> {note} If you have a custom **prompt** value and work with non-English language sites, you might want to update it manually to adopt the `{site.languageName}` variable which can return more reliable results in the desired language. Installs still using any former default prompt values are migrated automatically.
+
+- Changed the default prompt to name the target language explicitly — `{site.languageName} (BCP 47: {site.language})`, e.g. `Norwegian (BCP 47: no)`. The previous default ended in a bare code (`Output in the language: no` for Norwegian), which a model could misread as the English word "no" and answer in the wrong language.
 - Added a `{site.languageName}` prompt variable that resolves to the language's display name only.
 - The prompt is now sent as the system/instruction message for both providers — Anthropic via `system`, and OpenAI via the Responses API top-level `instructions` parameter. The user turn now carries only the image and the shared generation trigger.
 - Fixed a bug where saving a setting from a migration could replace all other stored plugin settings (API keys, provider, model, etc.) in project config. Both the new prompt migration and the existing AI provider migration now merge the single changed setting into the stored settings instead, and skip safely (with a warning) on environments where `allowAdminChanges` is disabled instead of failing the update.
 - Bumped the plugin schema version so pending migrations are actually detected and run by Craft's updater.
 - Fixed a bug where root-relative asset/transform URLs (e.g. from a site with a path-only base URL like `/en`, or during console/queue requests) were sent unresolved to the AI provider and the base64 fallback, causing both to fail. They are now resolved against the primary site's host.
-- Fixed alt text generation throwing an error when no site ID is provided; it now falls back to the asset's own site.
-- Corrected a misleading warning message that reported a supported MIME type as unsupported when falling back to source file contents for base64 encoding.
 
 ## 1.9.1 - 2026-06-09
 - Removed the plugin-level preflight check before sending a request with an image URL to an AI provider. A CDN (e.g. TwicPics) could reject the preflight request from the plugin despite the file being publicly available and accepted by an AI provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 > {note} If you customised the **prompt** setting, it is left untouched — update it manually to adopt the `{site.languageName}` variable which can offer better results for non-english language sites. Installs still using any former default prompt are migrated automatically.
 
-- Changed the default prompt to output the language as `{site.languageName} ({site.language})` (e.g. `English (United Kingdom) (en-GB)`), making the language fully visible and editable. Existing installs whose stored prompt matches any former default prompt are automatically migrated to the new one; any customised prompt is left untouched.
+- Changed the default prompt to output the language as `{site.languageName} (BCP 47: {site.language})` (e.g. `English (United Kingdom) (BCP 47: en-GB)`), making the language fully visible and editable. Existing installs whose stored prompt matches any former default prompt are automatically migrated to the new one; any customised prompt is left untouched.
 - Added a `{site.languageName}` prompt token that resolves to the language's display name only.
 - The prompt is now sent as the system/instruction message for both providers — Anthropic via `system`, and OpenAI via the Responses API top-level `instructions` parameter. The user turn now carries only the image and the shared generation trigger.
 - Fixed a bug where saving a setting from a migration could replace all other stored plugin settings (API keys, provider, model, etc.) in project config. Both the new prompt migration and the existing AI provider migration now merge the single changed setting into the stored settings instead, and skip safely (with a warning) on environments where `allowAdminChanges` is disabled instead of failing the update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release Notes for AI Alt Text
 
-## Unreleased
+## 1.10.0 - 2026-07-07
 > {note} If you customised the **prompt** setting, it is left untouched — update it manually to adopt the `{site.languageName}` variable which can offer better results for non-english language sites. Installs still using any former default prompt are migrated automatically.
 
 - Changed the default prompt to output the language as `{site.languageName} (BCP 47: {site.language})` (e.g. `English (United Kingdom) (BCP 47: en-GB)`), making the language fully visible and editable. Existing installs whose stored prompt matches any former default prompt are automatically migrated to the new one; any customised prompt is left untouched.
-- Added a `{site.languageName}` prompt token that resolves to the language's display name only.
+- Added a `{site.languageName}` prompt variable that resolves to the language's display name only.
 - The prompt is now sent as the system/instruction message for both providers — Anthropic via `system`, and OpenAI via the Responses API top-level `instructions` parameter. The user turn now carries only the image and the shared generation trigger.
 - Fixed a bug where saving a setting from a migration could replace all other stored plugin settings (API keys, provider, model, etc.) in project config. Both the new prompt migration and the existing AI provider migration now merge the single changed setting into the stored settings instead, and skip safely (with a warning) on environments where `allowAdminChanges` is disabled instead of failing the update.
 - Bumped the plugin schema version so pending migrations are actually detected and run by Craft's updater.

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -97,7 +97,7 @@ Example twig:
 | `ai-alt-text/generate/stats` | Show alt text coverage statistics |
 | `ai-alt-text/generate/missing` | Queue jobs for assets without alt text (recommended) |
 | `ai-alt-text/generate/all` | Queue jobs for ALL assets (⚠️ overwrites existing alt text) |
-| `ai-alt-text/generate/single <id>` | Queue job for a specific asset ID |
+| `ai-alt-text/generate/single <id> [siteId]` | Queue job for a specific asset ID (optionally for one site) |
 
 ### Options
 
@@ -122,6 +122,9 @@ Example twig:
 
 # Queue for single asset
 ./craft ai-alt-text/generate/single 123
+
+# Queue for single asset on a specific site
+./craft ai-alt-text/generate/single 123 2
 ```
 
 ## ⚙️ Plugin settings
@@ -137,7 +140,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
 | **OpenAI Reasoning Effort**| The reasoning effort level for OpenAI reasoning models. |
-| **Prompt** | The text prompt sent to the AI providers (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` |
+| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` tokens, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
 | **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
 | **Process SVGs** | Attempt to generate alt text for SVG files when they are uploaded or batched processed. |
@@ -153,7 +156,9 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
+This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its locale ID, so the default pairs them — edit the parenthesised format freely.
+
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})
 
 #### 🔍 Image detail options
 

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -156,9 +156,9 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its locale ID, so the default pairs them — edit the parenthesised format freely.
+This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its BCP 47 language tag (e.g. `en-GB`), so the default pairs them — edit the parenthesised format freely.
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} (BCP 47: {site.language})
 
 #### 🔍 Image detail options
 

--- a/PLUGIN_STORE_README.md
+++ b/PLUGIN_STORE_README.md
@@ -140,7 +140,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
 | **OpenAI Reasoning Effort**| The reasoning effort level for OpenAI reasoning models. |
-| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` tokens, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
+| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` variables, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
 | **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
 | **Process SVGs** | Attempt to generate alt text for SVG files when they are uploaded or batched processed. |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Example twig:
 | `ai-alt-text/generate/stats` | Show alt text coverage statistics |
 | `ai-alt-text/generate/missing` | Queue jobs for assets without alt text (recommended) |
 | `ai-alt-text/generate/all` | Queue jobs for ALL assets (⚠️ overwrites existing alt text) |
-| `ai-alt-text/generate/single <id>` | Queue job for a specific asset ID |
+| `ai-alt-text/generate/single <id> [siteId]` | Queue job for a specific asset ID (optionally for one site) |
 
 ### Options
 
@@ -122,6 +122,9 @@ Example twig:
 
 # Queue for single asset
 ./craft ai-alt-text/generate/single 123
+
+# Queue for single asset on a specific site
+./craft ai-alt-text/generate/single 123 2
 ```
 
 ## ⚙️ Plugin settings
@@ -137,7 +140,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
 | **OpenAI Reasoning Effort**| The reasoning effort level for OpenAI reasoning models. |
-| **Prompt** | The text prompt sent to the AI providers (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` |
+| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` tokens, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
 | **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
 | **Process SVGs** | Attempt to generate alt text for SVG files when they are uploaded or batched processed. |
@@ -153,7 +156,9 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}
+This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its locale ID, so the default pairs them — edit the parenthesised format freely.
+
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})
 
 #### 🔍 Image detail options
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ To find out which models are capable of vision, check [the models page](https://
 
 #### 💬 Default prompt
 
-This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its locale ID, so the default pairs them — edit the parenthesised format freely.
+This is sent to the provider as the system / instruction message (Anthropic `system`, OpenAI `instructions`); the image is sent in the user turn with a short trigger. `{site.languageName}` resolves to the language's display name and `{site.language}` to its BCP 47 language tag (e.g. `en-GB`), so the default pairs them — edit the parenthesised format freely.
 
-> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})
+> Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don't suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} (BCP 47: {site.language})
 
 #### 🔍 Image detail options
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ After installation, configure the plugin at **Settings → AI Alt Text**:
 | **Model** | The AI model to use (e.g., `gpt-5-nano` or `claude-haiku-4-5`). |
 | **Detail Level**| How detailed the image analysis should be (controls resolution/scaling). |
 | **OpenAI Reasoning Effort**| The reasoning effort level for OpenAI reasoning models. |
-| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` tokens, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
+| **Prompt** | The instructions sent to the AI provider as the system / instruction message (example [below](#default-prompt)). Supports `{asset.property}` and `{site.property}` variables, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). |
 | **Propagate** | Whether the asset should be saved across all of its supported sites, if enabled it could save the same initial alt text value across all sites. |
 | **Generate for new image assets (on upload)** | Automatically generate alt text when new assets are created. |
 | **Process SVGs** | Attempt to generate alt text for SVG files when they are uploaded or batched processed. |

--- a/src/AiAltText.php
+++ b/src/AiAltText.php
@@ -28,7 +28,7 @@ use yii\base\Event;
  */
 class AiAltText extends Plugin
 {
-    public string $schemaVersion = '1.0.0';
+    public string $schemaVersion = '1.1.0';
     public bool $hasCpSettings = true;
 
     public static function config(): array

--- a/src/migrations/m260312_215324_setting_ai_provider.php
+++ b/src/migrations/m260312_215324_setting_ai_provider.php
@@ -4,7 +4,6 @@ namespace heavymetalavo\craftaialttext\migrations;
 
 use Craft;
 use craft\db\Migration;
-use heavymetalavo\craftaialttext\AiAltText;
 
 /**
  * m260312_215324_setting_ai_provider migration.
@@ -16,20 +15,35 @@ class m260312_215324_setting_ai_provider extends Migration
      */
     public function safeUp(): bool
     {
-        $plugin = AiAltText::getInstance();
-        if ($plugin === null) {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        // If the incoming project config was produced by an environment that
+        // already ran this migration, the new value arrives through the normal
+        // project config apply — don't write it again.
+        $schemaVersion = $projectConfig->get('plugins.ai-alt-text.schemaVersion', true);
+        if ($schemaVersion !== null && version_compare($schemaVersion, '1.1.0', '>=')) {
             return true;
         }
 
-        $settings = $plugin->getSettings();
+        $settings = $projectConfig->get('plugins.ai-alt-text.settings') ?? [];
 
         // If provider is not set, but an OpenAI key exists, default to openai
-        if (empty($settings->aiProvider) && !empty($settings->openAiApiKey)) {
-            Craft::info('Migrating AI provider to "openai" based on existing API key.', __METHOD__);
-            Craft::$app->getPlugins()->savePluginSettings($plugin, [
-                'aiProvider' => 'openai'
-            ]);
+        if (!empty($settings['aiProvider'] ?? null) || empty($settings['openAiApiKey'] ?? null)) {
+            return true;
         }
+
+        if (!Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
+            Craft::warning('Skipping AI provider migration: project config is read-only on this environment (allowAdminChanges is false). Run the update on an environment that allows admin changes and deploy the resulting project config.', __METHOD__);
+            return true;
+        }
+
+        Craft::info('Migrating AI provider to "openai" based on existing API key.', __METHOD__);
+
+        // Write the whole settings node back with only `aiProvider` changed, so
+        // no other stored settings are lost. (Plugins::savePluginSettings()
+        // would replace the node with only the keys passed to it.)
+        $settings['aiProvider'] = 'openai';
+        $projectConfig->set('plugins.ai-alt-text.settings', $settings, 'Set AI Alt Text provider to openai for existing OpenAI installs');
 
         return true;
     }

--- a/src/migrations/m260630_224145_migrate_prompt_language_token.php
+++ b/src/migrations/m260630_224145_migrate_prompt_language_token.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace heavymetalavo\craftaialttext\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m260630_224145_migrate_prompt_language_token migration.
+ *
+ * Upgrades the stored `prompt` setting to the new default that uses the
+ * `{site.languageName}` token, but ONLY when the stored value verbatim-matches
+ * one of the default prompts shipped by a previous release. A verbatim match
+ * means the user never customised the prompt, so upgrading them to the current
+ * default is safe; any customised prompt is left untouched.
+ */
+class m260630_224145_migrate_prompt_language_token extends Migration
+{
+    /**
+     * Every default prompt shipped by a previous release, oldest first.
+     * Frozen here on purpose — do not reference the live Settings default,
+     * which may change again in a future release.
+     */
+    private const OLD_DEFAULT_PROMPTS = [
+        // 2025-03-23 (initial release)
+        'Please provide a detailed description of this image that would be suitable as alt text. Focus on the visual elements, context, and purpose of the image.',
+        // 2025-03-23
+        'Generate a brief (roughly 150 characters maximum) alt text description focusing on the main subject and overall composition. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image.',
+        // 2025-03-31 (added {site.language})
+        'Generate a brief (roughly 150 characters maximum) alt text description focusing on the main subject and overall composition. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}',
+        // 2025-06-27 (rewrite; also reintroduced 2026-03-04 without the gender clause)
+        'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. Output in {site.language}',
+        // 2025-08-19 (added the gender clause; reinstated 2026-03-14)
+        'Describe the image provided, make it suitable for an alt text description (roughly 150 characters maximum). Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. Do not add a prefix of any kind (e.g. alt text: AI content) so the value is suitable for the alt text attribute value of the image. When describing a person do not assume their gender. Output in {site.language}',
+        // 2026-03-19 (immediately-previous default)
+        'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}',
+    ];
+
+    /**
+     * The new default introduced by this release.
+     */
+    private const NEW_DEFAULT_PROMPT = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})';
+
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        // If the incoming project config was produced by an environment that
+        // already ran this migration, the new value arrives through the normal
+        // project config apply — don't write it again.
+        $schemaVersion = $projectConfig->get('plugins.ai-alt-text.schemaVersion', true);
+        if ($schemaVersion !== null && version_compare($schemaVersion, '1.1.0', '>=')) {
+            return true;
+        }
+
+        $settings = $projectConfig->get('plugins.ai-alt-text.settings') ?? [];
+
+        if (!in_array($settings['prompt'] ?? null, self::OLD_DEFAULT_PROMPTS, true)) {
+            return true;
+        }
+
+        if (!Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
+            Craft::warning('Skipping prompt migration: project config is read-only on this environment (allowAdminChanges is false). Run the update on an environment that allows admin changes and deploy the resulting project config.', __METHOD__);
+            return true;
+        }
+
+        Craft::info('Migrating prompt setting to the new default using {site.languageName}.', __METHOD__);
+
+        // Write the whole settings node back with only `prompt` changed, so no
+        // other stored settings are lost. (Plugins::savePluginSettings() would
+        // replace the node with only the keys passed to it.)
+        $settings['prompt'] = self::NEW_DEFAULT_PROMPT;
+        $projectConfig->set('plugins.ai-alt-text.settings', $settings, 'Update AI Alt Text default prompt to use {site.languageName}');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m260630_224145_migrate_prompt_language_token cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m260630_224145_migrate_prompt_language_token.php
+++ b/src/migrations/m260630_224145_migrate_prompt_language_token.php
@@ -39,7 +39,7 @@ class m260630_224145_migrate_prompt_language_token extends Migration
     /**
      * The new default introduced by this release.
      */
-    private const NEW_DEFAULT_PROMPT = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})';
+    private const NEW_DEFAULT_PROMPT = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} (BCP 47: {site.language})';
 
     /**
      * @inheritdoc

--- a/src/migrations/m260630_224145_migrate_prompt_to_language_name.php
+++ b/src/migrations/m260630_224145_migrate_prompt_to_language_name.php
@@ -6,7 +6,7 @@ use Craft;
 use craft\db\Migration;
 
 /**
- * m260630_224145_migrate_prompt_language_token migration.
+ * m260630_224145_migrate_prompt_to_language_name migration.
  *
  * Upgrades the stored `prompt` setting to the new default that uses the
  * `{site.languageName}` token, but ONLY when the stored value verbatim-matches
@@ -14,7 +14,7 @@ use craft\db\Migration;
  * means the user never customised the prompt, so upgrading them to the current
  * default is safe; any customised prompt is left untouched.
  */
-class m260630_224145_migrate_prompt_language_token extends Migration
+class m260630_224145_migrate_prompt_to_language_name extends Migration
 {
     /**
      * Every default prompt shipped by a previous release, oldest first.
@@ -83,7 +83,7 @@ class m260630_224145_migrate_prompt_language_token extends Migration
      */
     public function safeDown(): bool
     {
-        echo "m260630_224145_migrate_prompt_language_token cannot be reverted.\n";
+        echo "m260630_224145_migrate_prompt_to_language_name cannot be reverted.\n";
         return false;
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     /**
      * @var string The prompt template for generating alt text
      */
-    public string $prompt = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})';
+    public string $prompt = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} (BCP 47: {site.language})';
 
     /**
      * @var string The detail level for image analysis

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,7 @@ class Settings extends Model
     /**
      * @var string The prompt template for generating alt text
      */
-    public string $prompt = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.language}';
+    public string $prompt = 'Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. "#", "alt text:", "An image of", "A photo of"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})';
 
     /**
      * @var string The detail level for image analysis

--- a/src/models/api/AnthropicRequest.php
+++ b/src/models/api/AnthropicRequest.php
@@ -14,9 +14,21 @@ class AnthropicRequest extends Model
     public string $model = '';
     public int $maxTokens = 1024;
 
+    private string $system = '';
     private string $prompt = '';
     private ?string $imageUrl = null;
     private ?array $imageSource = null;
+
+    /**
+     * Sets the system instructions for the request (task, output format, language, etc.), sent as
+     * the top-level `system` parameter, which the model weights more strongly than text in the
+     * user content — improving adherence to directives such as the output language.
+     */
+    public function setSystem(string $system): self
+    {
+        $this->system = $system;
+        return $this;
+    }
 
     public function setPrompt(string $prompt): self
     {
@@ -80,7 +92,7 @@ class AnthropicRequest extends Model
             ];
         }
 
-        return [
+        $payload = [
             'model' => $this->model,
             'max_tokens' => $this->maxTokens,
             'messages' => [
@@ -90,5 +102,11 @@ class AnthropicRequest extends Model
                 ],
             ],
         ];
+
+        if (!empty($this->system)) {
+            $payload['system'] = $this->system;
+        }
+
+        return $payload;
     }
 }

--- a/src/models/api/OpenAiRequest.php
+++ b/src/models/api/OpenAiRequest.php
@@ -15,6 +15,7 @@ class OpenAiRequest extends Model
 {
     public string $model = '';
 
+    private string $instructions = '';
     private string $prompt = '';
     private string $imageUrl = '';
     private string $detail = 'low';
@@ -23,6 +24,17 @@ class OpenAiRequest extends Model
     public function getDetail(): string
     {
         return $this->detail;
+    }
+
+    /**
+     * Sets the system-level instructions (task, output format, language, etc.), emitted as the
+     * Responses API top-level `instructions` parameter, which the model weights more strongly than
+     * text in the user input.
+     */
+    public function setInstructions(string $instructions): self
+    {
+        $this->instructions = $instructions;
+        return $this;
     }
 
     public function setReasoningEffort(string $reasoningEffort): self
@@ -100,6 +112,10 @@ class OpenAiRequest extends Model
                 ],
             ],
         ];
+
+        if (!empty($this->instructions)) {
+            $payload['instructions'] = $this->instructions;
+        }
 
         if ($this->isReasoningModel()) {
             $payload['reasoning']['effort'] = $this->reasoningEffort;

--- a/src/services/AnthropicService.php
+++ b/src/services/AnthropicService.php
@@ -96,20 +96,12 @@ class AnthropicService extends ApiService
             // Log the request intent for debugging
             Craft::info('Anthropic API request initiated for asset: ' . $asset->filename . ' with image URL: ' . $imageUrl, __METHOD__);
 
-            $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
-
-            $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
-                return $asset->{$matches[1]};
-            }, $promptTemplate);
-
-            $site = Craft::$app->getSites()->getSiteById($siteId);
-            $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
-                return $site->{$matches[1]};
-            }, $prompt);
+            $prompt = $this->resolvePrompt($asset, $siteId);
 
             $requestModel = new AnthropicRequest();
             $requestModel->model = $this->model;
-            $requestModel->setPrompt($prompt);
+            $requestModel->setSystem($prompt);
+            $requestModel->setPrompt(self::GENERATE_TRIGGER);
             if ($base64ImageSource) {
                 $requestModel->setImageSource($base64ImageSource);
             } elseif ($imageUrl) {

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -63,10 +63,10 @@ abstract class ApiService extends Component
      * {site.languageName} resolves to the site language's display name, e.g. "English (United
      * Kingdom)" — the same value Craft shows in its language dropdown ($locale->getDisplayName(
      * Craft::$app->language)). It needs a dedicated case because it maps to a method chain rather
-     * than a property. The locale ID itself is available via the ordinary {site.language} token, so
-     * the default prompt pairs them ("{site.languageName} ({site.language})") and the format stays
-     * visible and editable in the prompt. Other {site.*} / {asset.*} tokens resolve to the matching
-     * property.
+     * than a property. The BCP 47 language tag itself is available via the ordinary {site.language}
+     * token, so the default prompt pairs them ("{site.languageName} (BCP 47: {site.language})") and
+     * the format stays visible and editable in the prompt. Other {site.*} / {asset.*} tokens resolve
+     * to the matching property.
      */
     protected function resolvePrompt(Asset $asset, ?int $siteId): string
     {

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -67,6 +67,13 @@ abstract class ApiService extends Component
      * token, so the default prompt pairs them ("{site.languageName} (BCP 47: {site.language})") and
      * the format stays visible and editable in the prompt. Other {site.*} / {asset.*} tokens resolve
      * to the matching property.
+     *
+     * @todo Consider making $siteId a required `int` and dropping the `?? $asset->getSite()`
+     *       fallback below — in practice $siteId is never null (every caller resolves a concrete
+     *       site). Doing it cleanly means tightening ?int → int across the call chain (the abstract
+     *       generateAltText(), OpenAiService & AnthropicService generateAltText()/sendRequest(),
+     *       and AiAltTextService::generateAltText()), with the one genuine guard at the queue job,
+     *       whose siteId payload is legitimately nullable (`$this->siteId ?? $asset->siteId`).
      */
     protected function resolvePrompt(Asset $asset, ?int $siteId): string
     {

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -5,6 +5,7 @@ namespace heavymetalavo\craftaialttext\services;
 use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
+use craft\helpers\App;
 use craft\helpers\UrlHelper;
 use Exception;
 use GuzzleHttp\Client;
@@ -30,6 +31,12 @@ abstract class ApiService extends Component
     ];
 
     /**
+     * @var string Minimal user-turn trigger sent alongside the image. The substantive instructions
+     * live in the provider's system/instructions field (see resolvePrompt()).
+     */
+    protected const GENERATE_TRIGGER = 'Generate the alt text for this image now.';
+
+    /**
      * @var Client
      */
     protected Client $client;
@@ -48,6 +55,37 @@ abstract class ApiService extends Component
      * Required implementation for child services to generate their specific payloads.
      */
     abstract public function generateAltText(Asset $asset, ?int $siteId = null): string;
+
+    /**
+     * Resolves the configured prompt template into a final instruction string, substituting
+     * {asset.*} and {site.*} placeholders.
+     *
+     * {site.languageName} resolves to the site language's display name, e.g. "English (United
+     * Kingdom)" — the same value Craft shows in its language dropdown ($locale->getDisplayName(
+     * Craft::$app->language)). It needs a dedicated case because it maps to a method chain rather
+     * than a property. The locale ID itself is available via the ordinary {site.language} token, so
+     * the default prompt pairs them ("{site.languageName} ({site.language})") and the format stays
+     * visible and editable in the prompt. Other {site.*} / {asset.*} tokens resolve to the matching
+     * property.
+     */
+    protected function resolvePrompt(Asset $asset, ?int $siteId): string
+    {
+        $promptTemplate = App::parseEnv(AiAltText::getInstance()->getSettings()->prompt);
+
+        $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
+            return $asset->{$matches[1]};
+        }, $promptTemplate);
+
+        $site = ($siteId !== null ? Craft::$app->getSites()->getSiteById($siteId) : null) ?? $asset->getSite();
+        $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
+            if ($matches[1] === 'languageName') {
+                return $site->getLocale()->getDisplayName(Craft::$app->language);
+            }
+            return $site->{$matches[1]};
+        }, $prompt);
+
+        return $prompt;
+    }
 
     /**
      * Resolves an asset URL to an absolute URL for Guzzle and provider APIs.
@@ -75,6 +113,13 @@ abstract class ApiService extends Component
             $site = Craft::$app->getSites()->getSiteById($asset->siteId);
             $siteBaseUrl = $site?->getBaseUrl() ?: UrlHelper::baseSiteUrl();
             $hostInfo = UrlHelper::hostInfo($siteBaseUrl);
+
+            // A path-only site base URL (e.g. `/en-US`) has no host info, and in console/queue
+            // requests hostInfo() cannot fall back to the current request's host — use the
+            // primary site's host instead so the URL is absolute for Guzzle and providers.
+            if (empty($hostInfo)) {
+                $hostInfo = UrlHelper::hostInfo(UrlHelper::baseSiteUrl());
+            }
 
             return rtrim($hostInfo, '/') . $url;
         }
@@ -200,7 +245,7 @@ abstract class ApiService extends Component
             throw new Exception("Cannot generate alt text for {$asset->filename}: The transform or asset is not publicly available, or the image transform could not be downloaded, and the original format \"$originalMimeType\" is not supported natively by the AI provider.");
         }
 
-        Craft::warning("Asset {$asset->filename} has no publicly available URL and an unsupported MIME type \"$originalMimeType\". A transform is required but retrieving the file contents for a transform is unsupported. Continuing with source asset file contents for base64 encoding.", __METHOD__);
+        Craft::warning("Falling back to the source file contents of {$asset->filename} for base64 encoding: the (transformed) image URL was unavailable or could not be downloaded, and its source MIME type \"$originalMimeType\" is natively supported by the AI provider.", __METHOD__);
 
         return base64_encode($asset->getContents());
     }

--- a/src/services/OpenAiService.php
+++ b/src/services/OpenAiService.php
@@ -204,21 +204,7 @@ class OpenAiService extends ApiService
             $detail = App::parseEnv($plugin->getSettings()->openAiImageInputDetailLevel) ?? 'low';
         }
         
-        $prompt = App::parseEnv($plugin->getSettings()->prompt);
-
-        // parse $prompt for {asset.param} and replace with $asset->param
-        // make sure that if the string may contain "{asset.title}{asset.caption}" we only replace each occurrence, and do not capture "{asset.title}{asset.caption}"
-        $prompt = preg_replace_callback('/{asset\.(.*?)}/', function ($matches) use ($asset) {
-            return $asset->{$matches[1]};
-        }, $prompt);
-
-        // Get the $site
-        $site = Craft::$app->getSites()->getSiteById($siteId);
-
-        // parse $prompt for {site.param} and replace with $site->param
-        $prompt = preg_replace_callback('/{site\.(.*?)}/', function ($matches) use ($site) {
-            return $site->{$matches[1]};
-        }, $prompt);
+        $prompt = $this->resolvePrompt($asset, $siteId);
 
         // Log asset info for debugging
         Craft::info('Generating alt text for asset: ' . $asset->filename . ' (' . $imageUrl . ')', __METHOD__);
@@ -226,7 +212,8 @@ class OpenAiService extends ApiService
         // Create and populate the request model
         $request = new OpenAiRequest();
         $request->model = $this->model;
-        $request->setPrompt($prompt)
+        $request->setInstructions($prompt)
+            ->setPrompt(self::GENERATE_TRIGGER)
             ->setImageUrl($imageUrl)
             ->setReasoningEffort((string) App::parseEnv($plugin->getSettings()->openAiReasoningEffort));
             

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -161,9 +161,9 @@
     label: 'Prompt'|t('app'),
     id: 'prompt',
     name: 'prompt',
-    instructions: "Sent to the AI provider as the system / instruction message (the image is sent separately with a short trigger). Supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). Checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template."|t("aialttext"),
+    instructions: "Sent to the AI provider as the system / instruction message. The field supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`. Consider `{site.languageName}` for the site's language display name (e.g. `English (United Kingdom)`) which can help with translations on non-english sites. Checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template."|t("aialttext"),
     value: settings.prompt,
-    placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})",
+    placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.languageName} (BCP 47: {site.language})",
     errors: settings.getErrors('prompt'),
 }) }}
 

--- a/src/templates/_settings.twig
+++ b/src/templates/_settings.twig
@@ -161,9 +161,9 @@
     label: 'Prompt'|t('app'),
     id: 'prompt',
     name: 'prompt',
-    instructions: "The text prompt which will be sent to the AI provider with the image to generate the response, supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`, checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template.`"|t("aialttext"),
+    instructions: "Sent to the AI provider as the system / instruction message (the image is sent separately with a short trigger). Supports simple Asset Model and Site Model property values using `{asset.property}` and `{site.property}`, plus `{site.languageName}` for the language's display name (e.g. `English (United Kingdom)`). Checkout [the readme](https://github.com/heavymetalavo/craft-aialttext?tab=readme-ov-file#-default-prompt) for the most up to date suggestion prompt template."|t("aialttext"),
     value: settings.prompt,
-    placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.language}",
+    placeholder: "Describe the image provided (roughly 150 characters). The output MUST be suitable for use directly as an HTML alt attribute value. Consider transparency within the image if supported by the file type, e.g. don\'t suggest it has a dark background if it is transparent. When describing a person do not assume their gender. Do not add a prefix of any kind (e.g. \"#\", \"alt text:\", \"An image of\", \"A photo of\"). Do not wrap the output in quotes. Output in the language: {site.languageName} ({site.language})",
     errors: settings.getErrors('prompt'),
 }) }}
 


### PR DESCRIPTION
## What changed

Reworks how the prompt is delivered to the AI providers and makes the output language easier to control.

- **Prompt is now the system/instruction message.** The configured prompt is sent as the provider's system-level field (Anthropic `system`, OpenAI Responses API top-level `instructions`) rather than in the user turn. Models weight this more strongly, improving adherence to directives such as the output language. The user turn now carries only the image plus a shared generation trigger (`Generate the alt text for this image now.`).
- **New `{site.languageName}` variable** resolving to the language's display name (e.g. `English (United Kingdom)`), the same value Craft shows in its language dropdown. The default prompt now outputs `{site.languageName} (BCP 47: {site.language})` so the language is fully visible and editable.
- **Prompt placeholder resolution is shared** between both services via `ApiService::resolvePrompt()` (previously duplicated in each service).
- **Prompt migration** (`m260630_224145_migrate_prompt_to_language_name`) upgrades a stored prompt to the new default **only** when it verbatim-matches one of the former shipped defaults — a customised prompt is left untouched.
- **`savePluginSettings()` footgun fixed.** Both the new prompt migration and the existing AI-provider migration now merge the single changed setting into the stored project-config node instead of replacing the whole node (which would wipe API keys, provider, model, etc.), and skip safely with a warning when `allowAdminChanges` is disabled.
- **`schemaVersion` bumped to 1.1.0** so pending migrations are actually detected and run by Craft's updater.
- **Root-relative asset/transform URLs resolved against the primary site's host**, so a path-only site base URL (e.g. `/en`) or console/queue requests no longer send unresolved URLs to the provider and the base64 fallback.
- **Fall back to the asset's own site** when no site ID is provided (previously errored).
- **Corrected a misleading warning** that reported a supported MIME type as unsupported during base64 fallback.
- **`.gitignore`:** ignore agent-config files (`CLAUDE.md`, `.claude/`, `.cursorignore`).

## Why

The output language was being ignored on some non-English sites because language directives buried in the user turn were weighted weakly by the models. Promoting the prompt to the system/instructions field improves adherence, and exposing `{site.languageName}` gives clearer, editable control over the target language. The migration + `savePluginSettings()` fixes make the upgrade safe for existing installs without clobbering their stored settings.

> **Upgrade note:** a customised prompt is left untouched — update it manually to adopt `{site.languageName}` for better results on non-English sites. Installs still using a former default prompt are migrated automatically.

## How to test

1. **Settings page** — confirm the updated prompt default and instructions copy at [https://craft.ddev.site/admin/settings/plugins/ai-alt-text](https://craft.ddev.site/admin/settings/plugins/ai-alt-text)
2. **Generation** — run the CLI generation loop (asset 87) per `AGENTS.md` and confirm each site's alt text is written in that site's language.
3. **Migration** — verify a pre-existing default prompt is auto-migrated to the `{site.languageName}` default, while a customised prompt is left as-is.
